### PR TITLE
fix(ios): pass hostedDomain from configure() to GIDConfiguration

### DIFF
--- a/ios/HybridNitroGoogleSignin.swift
+++ b/ios/HybridNitroGoogleSignin.swift
@@ -54,10 +54,13 @@ class HybridNitroGoogleSignin: HybridNitroGoogleSigninSpec {
     offlineAccess = params.offlineAccess ?? false
     configuredNonce = Self.variantToString(params.nonce)
     configuredScopes = Self.variantToStringArray(params.scopes)
+    let hostedDomain = Self.variantToString(params.hostedDomain)
 
     let config = GIDConfiguration(
       clientID: iosClientId,
-      serverClientID: resolvedWeb
+      serverClientID: resolvedWeb,
+      hostedDomain: hostedDomain,
+      openIDRealm: nil
     )
     GIDSignIn.sharedInstance.configuration = config
     configured = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-google-signin",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "High-Performance Google Sign-In for React Native (Nitro Powered)",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index.js",


### PR DESCRIPTION
## Summary

- Fixes [#23](https://github.com/react-native-nitro-google-sign-in/google-signin/issues/23): `hostedDomain` from `configure()` is now forwarded to `GIDConfiguration` on iOS, enabling domain-restricted Google Workspace sign-in.
- Verified Android is **not** affected — `hostedDomain` is already stored in `GoogleSignInController` and applied via `GetGoogleIdOption.Builder.setHostedDomainFilter()`.

## Root cause

`HybridNitroGoogleSignin.configure()` built `GIDConfiguration` with only `clientID` and `serverClientID`, silently ignoring `hostedDomain` even though the TypeScript API exposes it.

## Fix

Read `params.hostedDomain` and pass it to the `GIDConfiguration` designated initializer (`hostedDomain`, `openIDRealm: nil`).

## Test plan

- [ ] Configure with `hostedDomain: "yourcompany.com"` on iOS and confirm only accounts from that domain can sign in
- [ ] Configure without `hostedDomain` and confirm any Google account can still sign in
- [ ] Smoke-test Android sign-in with and without `hostedDomain` (no code changes; regression check only)
