### PR TITLE
fix(android): implement proper revokeAccess support using Identity.getAuthorizationClient

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Install Pods (bare)
         if: matrix.label == 'bare'
         working-directory: example/ios
-        run: bundle exec pod install
+        run: pod install
 
       - name: Prepare Expo Google config for CI
         if: matrix.label == 'expo'

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -106,7 +106,7 @@ jobs:
           path: |
             ~/.cocoapods/repos
             ${{ matrix.cache-path }}
-          key: ${{ runner.os }}-pods-bare-${{ hashFiles('example/ios/Podfile.lock', 'NitroGoogleSignin.podspec') }}
+          key: ${{ runner.os }}-pods-bare-${{ hashFiles('example/ios/Podfile.lock', 'example/package.json', 'bun.lock', 'NitroGoogleSignin.podspec') }}
           restore-keys: |
             ${{ runner.os }}-pods-bare-
             ${{ runner.os }}-pods-
@@ -143,7 +143,10 @@ jobs:
       - name: Install Pods (bare)
         if: matrix.label == 'bare'
         working-directory: example/ios
-        run: pod install
+        run: |
+          # Restored Pods cache can leave stale Local Podspecs (e.g. hermes-engine).
+          rm -rf "Pods/Local Podspecs"
+          pod install
 
       - name: Prepare Expo Google config for CI
         if: matrix.label == 'expo'

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Live demos: [`example/App.tsx`](example/App.tsx) and [`example-expo/App.tsx`](ex
 | `presentExplicitSignIn()` | Explicit Sign in with Google UI.                                                                                                                 |
 | `requestScopes(scopes)`   | Request **additional** OAuth access after sign-in; returns `{ serverAuthCode }`.                                                                 |
 | `signOut()`               | Clears local Google session (iOS SDK); disable auto sign-in on Android.                                                                          |
-| `revokeAccess(id)`        | Disconnect app (iOS); no-op token revoke on Android CredMan.                                                                                     |
+| `revokeAccess(id)`        | Disconnect app (revokes app access / OAuth grant on both iOS and Android).                                                                       |
 
 
 Also exported: native [`GoogleSignInButton`](https://react-native-nitro-google-sign-in.github.io/docs/guide/google-sign-in-button), `useGoogleSignInFromButton`, response helpers (`isSuccessResponse`, `isNoSavedCredentialFoundResponse`, `isCancelledResponse`, `isErrorWithCode`), and `statusCodes`.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ You can request Google API access in two ways. Use **full scope URLs** (not shor
 
 #### Option A — scopes at configure time (first sign-in)
 
-Request scopes up front. Set `offlineAccess: true` if your backend needs a `serverAuthCode` to exchange for refresh tokens:
+Request scopes up front. **`offlineAccess: true` is required** when your backend needs a `serverAuthCode` to exchange for refresh tokens:
 
 ```ts
 import {
@@ -221,7 +221,9 @@ const signInWithScopesUpFront = async () => {
 
 #### Option B — scopes after sign-in (`requestScopes`)
 
-Start with basic sign-in, then request more access when the user needs a feature:
+Start with basic sign-in, then request more access when the user needs a feature.
+
+**`offlineAccess: true` in `configure()` is required** for a non-null `serverAuthCode` from `requestScopes()`:
 
 ```ts
 import {
@@ -231,7 +233,10 @@ import {
 
 const CALENDAR_READONLY = 'https://www.googleapis.com/auth/calendar.readonly'
 
-GoogleOneTapSignIn.configure({ webClientId: 'autoDetect' })
+GoogleOneTapSignIn.configure({
+  webClientId: 'autoDetect',
+  offlineAccess: true,
+})
 
 // 1) Sign in first (basic profile / idToken only)
 const signInThenRequestScopes = async () => {
@@ -270,12 +275,12 @@ Live demos: [`example/App.tsx`](example/App.tsx) and [`example-expo/App.tsx`](ex
 
 | Method                    | Description                                                                                                                                      |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `configure(params)`       | Required before other calls. `webClientId` or `'autoDetect'`; optional `scopes`, `offlineAccess`, `hostedDomain`, `nonce`, `autoSelectOnSignIn`. |
+| `configure(params)`       | Required before other calls. `webClientId` or `'autoDetect'`; optional `scopes`, `offlineAccess` (**required for `serverAuthCode`**), `hostedDomain`, `nonce`, `autoSelectOnSignIn`. |
 | `checkPlayServices()`     | Android: validates Play Services. iOS: no-op resolve.                                                                                            |
 | `signIn()`                | Silent / restore previous sign-in.                                                                                                               |
 | `createAccount()`         | Interactive account picker (sign-up).                                                                                                            |
 | `presentExplicitSignIn()` | Explicit Sign in with Google UI.                                                                                                                 |
-| `requestScopes(scopes)`   | Request **additional** OAuth access after sign-in; returns `{ serverAuthCode }`.                                                                 |
+| `requestScopes(scopes)`   | Request **additional** OAuth access after sign-in; returns `{ serverAuthCode }`. Requires `offlineAccess: true` in `configure()` for a non-null code. |
 | `signOut()`               | Clears local Google session (iOS SDK); disable auto sign-in on Android.                                                                          |
 | `revokeAccess(id)`        | Disconnect app (revokes app access / OAuth grant on both iOS and Android).                                                                       |
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -147,6 +147,9 @@ dependencies {
   implementation "com.google.android.gms:play-services-auth:21.6.0"
 
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.1"
+
+  // Secure storage for mapping google user ID to email for revocation
+  implementation "androidx.security:security-crypto:1.1.0"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/java/com/nitrogooglesignin/GoogleSignInAuthorizationHelper.kt
+++ b/android/src/main/java/com/nitrogooglesignin/GoogleSignInAuthorizationHelper.kt
@@ -62,6 +62,7 @@ internal object GoogleSignInAuthorizationHelper : ActivityEventListener {
           .setRequestedScopes(resolvedScopes.map { Scope(it) })
       if (offlineAccess) {
         requestBuilder.requestOfflineAccess(serverClientId)
+        requestBuilder.setPrompt(AuthorizationRequest.Prompt.CONSENT)
       }
 
       Identity.getAuthorizationClient(activity)
@@ -130,7 +131,12 @@ internal object GoogleSignInAuthorizationHelper : ActivityEventListener {
     clearPending(continuation)
 
     if (resultCode != Activity.RESULT_OK || data == null) {
-      continuation.resume(null)
+      continuation.resumeWithException(
+        GoogleSignInException(
+          code = "SIGN_IN_CANCELLED",
+          message = "Flow cancelled or failed with resultCode: $resultCode"
+        )
+      )
       return
     }
 

--- a/android/src/main/java/com/nitrogooglesignin/GoogleSignInController.kt
+++ b/android/src/main/java/com/nitrogooglesignin/GoogleSignInController.kt
@@ -23,8 +23,17 @@ import com.margelo.nitro.nitrogooglesignin.OneTapSuccessData
 import com.margelo.nitro.nitrogooglesignin.OneTapUser
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 import java.security.MessageDigest
 import java.util.UUID
+import android.accounts.Account
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import com.google.android.gms.auth.api.identity.Identity
+import com.google.android.gms.auth.api.identity.RevokeAccessRequest
 
 internal object GoogleSignInController {
   private var webClientId: String? = null
@@ -125,8 +134,41 @@ internal object GoogleSignInController {
     }
   }
 
-  suspend fun revokeAccess(@Suppress("UNUSED_PARAMETER") emailOrUniqueId: String) {
-    signOut()
+  suspend fun revokeAccess(emailOrUniqueId: String) {
+    val context = requireContext()
+    val activity = requireActivity()
+
+    val email = if (emailOrUniqueId.contains("@")) {
+      emailOrUniqueId
+    } else {
+      getEmailFromStorage(context, emailOrUniqueId) ?: emailOrUniqueId
+    }
+
+    val account = Account(email, "com.google")
+    val request = RevokeAccessRequest.builder()
+      .setAccount(account)
+      .build()
+
+    try {
+      suspendCancellableCoroutine<Void?> { continuation ->
+        Identity.getAuthorizationClient(activity)
+          .revokeAccess(request)
+          .addOnSuccessListener {
+            continuation.resume(null)
+          }
+          .addOnFailureListener { exception ->
+            continuation.resumeWithException(exception)
+          }
+      }
+    } catch (e: Exception) {
+      throw GoogleSignInException(
+        code = "REVOKE_ACCESS_FAILED",
+        message = e.message ?: "Failed to revoke access.",
+      )
+    } finally {
+      removeEmailFromStorage(context, emailOrUniqueId)
+      signOut()
+    }
   }
 
   suspend fun requestScopes(scopes: Array<String>): OneTapAuthorizationResult {
@@ -229,6 +271,10 @@ internal object GoogleSignInController {
         photo = googleCredential.profilePictureUri?.toString().toOptionalStringVariant(),
       )
 
+    email?.let {
+      saveEmailToStorage(requireContext(), userId, it)
+    }
+
     return OneTapSuccessData(
       user = profileUser,
       idToken = googleCredential.idToken,
@@ -279,6 +325,59 @@ internal object GoogleSignInController {
     val raw = UUID.randomUUID().toString()
     val digest = MessageDigest.getInstance("SHA-256").digest(raw.toByteArray())
     return digest.joinToString("") { "%02x".format(it) }
+  }
+
+  private const val PREFS_FILE_NAME = "google_signin_secure_prefs"
+
+  private fun getEncryptedPrefs(context: Context): SharedPreferences {
+    val masterKey = MasterKey.Builder(context)
+      .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+      .build()
+    return EncryptedSharedPreferences.create(
+      context,
+      PREFS_FILE_NAME,
+      masterKey,
+      EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+      EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+  }
+
+  private fun saveEmailToStorage(context: Context, uniqueId: String, email: String) {
+    try {
+      val prefs = getEncryptedPrefs(context)
+      prefs.edit().putString(uniqueId, email).apply()
+    } catch (e: Exception) {
+      // Log or silently ignore to not crash sign-in on encrypted prefs failure
+    }
+  }
+
+  private fun getEmailFromStorage(context: Context, uniqueId: String): String? {
+    return try {
+      val prefs = getEncryptedPrefs(context)
+      prefs.getString(uniqueId, null)
+    } catch (e: Exception) {
+      null
+    }
+  }
+
+  private fun removeEmailFromStorage(context: Context, emailOrUniqueId: String) {
+    try {
+      val prefs = getEncryptedPrefs(context)
+      if (emailOrUniqueId.contains("@")) {
+        // If it is an email, find the key (uniqueId) that maps to this email, and remove it.
+        val allPrefs = prefs.all
+        for ((key, value) in allPrefs) {
+          if (value == emailOrUniqueId) {
+            prefs.edit().remove(key).apply()
+          }
+        }
+      } else {
+        // If it's a uniqueId, remove it directly.
+        prefs.edit().remove(emailOrUniqueId).apply()
+      }
+    } catch (e: Exception) {
+      // Silently ignore
+    }
   }
 
   private fun requireContext(): ReactApplicationContext =

--- a/android/src/main/java/com/nitrogooglesignin/GoogleSignInController.kt
+++ b/android/src/main/java/com/nitrogooglesignin/GoogleSignInController.kt
@@ -145,10 +145,23 @@ internal object GoogleSignInController {
       getEmailFromStorage(context, emailOrUniqueId) ?: emailOrUniqueId
     }
 
+    val uniqueId = if (emailOrUniqueId.contains("@")) {
+      getUniqueIdFromStorage(context, emailOrUniqueId) ?: emailOrUniqueId
+    } else {
+      emailOrUniqueId
+    }
+
+    val savedScopes = getScopesFromStorage(context, uniqueId)
+    val finalScopes = if (savedScopes.isEmpty()) {
+      (configuredScopes + listOf("openid", "email", "profile")).toSet()
+    } else {
+      savedScopes
+    }
+
     val account = Account(email, "com.google")
     val request = RevokeAccessRequest.builder()
       .setAccount(account)
-      .setScopes(emptyList<Scope>())
+      .setScopes(finalScopes.map { Scope(it) })
       .build()
 
     try {
@@ -168,7 +181,7 @@ internal object GoogleSignInController {
         message = e.message ?: "Failed to revoke access.",
       )
     } finally {
-      removeEmailFromStorage(context, emailOrUniqueId)
+      removeUserDataFromStorage(context, emailOrUniqueId)
       signOut()
     }
   }
@@ -183,6 +196,15 @@ internal object GoogleSignInController {
         scopes = scopes.toList(),
         offlineAccess = offlineAccess,
       )
+
+    val context = requireContext()
+    val lastUserId = getLastSignedInUserId(context)
+    if (lastUserId != null) {
+      val existingScopes = getScopesFromStorage(context, lastUserId)
+      val updatedScopes = existingScopes + scopes.toList()
+      saveScopesToStorage(context, lastUserId, updatedScopes)
+    }
+
     return OneTapAuthorizationResult(serverAuthCode = authCode.toOptionalStringVariant())
   }
 
@@ -275,6 +297,8 @@ internal object GoogleSignInController {
 
     email?.let {
       saveEmailToStorage(requireContext(), userId, it)
+      val initialScopes = (configuredScopes + listOf("openid", "email", "profile")).toSet()
+      saveScopesToStorage(requireContext(), userId, initialScopes)
     }
 
     return OneTapSuccessData(
@@ -347,7 +371,11 @@ internal object GoogleSignInController {
   private fun saveEmailToStorage(context: Context, uniqueId: String, email: String) {
     try {
       val prefs = getEncryptedPrefs(context)
-      prefs.edit().putString(uniqueId, email).apply()
+      prefs.edit()
+        .putString(uniqueId, email)
+        .putString(email, uniqueId)
+        .putString("last_signed_in_user_id", uniqueId)
+        .apply()
     } catch (e: Exception) {
       // Log or silently ignore to not crash sign-in on encrypted prefs failure
     }
@@ -362,21 +390,59 @@ internal object GoogleSignInController {
     }
   }
 
-  private fun removeEmailFromStorage(context: Context, emailOrUniqueId: String) {
+  private fun getUniqueIdFromStorage(context: Context, email: String): String? {
+    return try {
+      val prefs = getEncryptedPrefs(context)
+      prefs.getString(email, null)
+    } catch (e: Exception) {
+      null
+    }
+  }
+
+  private fun getLastSignedInUserId(context: Context): String? {
+    return try {
+      val prefs = getEncryptedPrefs(context)
+      prefs.getString("last_signed_in_user_id", null)
+    } catch (e: Exception) {
+      null
+    }
+  }
+
+  private fun saveScopesToStorage(context: Context, uniqueId: String, scopes: Set<String>) {
     try {
       val prefs = getEncryptedPrefs(context)
-      if (emailOrUniqueId.contains("@")) {
-        // If it is an email, find the key (uniqueId) that maps to this email, and remove it.
-        val allPrefs = prefs.all
-        for ((key, value) in allPrefs) {
-          if (value == emailOrUniqueId) {
-            prefs.edit().remove(key).apply()
-          }
-        }
+      prefs.edit().putStringSet("${uniqueId}_scopes", scopes).apply()
+    } catch (e: Exception) {}
+  }
+
+  private fun getScopesFromStorage(context: Context, uniqueId: String): Set<String> {
+    return try {
+      val prefs = getEncryptedPrefs(context)
+      prefs.getStringSet("${uniqueId}_scopes", null) ?: emptySet()
+    } catch (e: Exception) {
+      emptySet()
+    }
+  }
+
+  private fun removeUserDataFromStorage(context: Context, emailOrUniqueId: String) {
+    try {
+      val prefs = getEncryptedPrefs(context)
+      val (email, uniqueId) = if (emailOrUniqueId.contains("@")) {
+        val resolvedId = prefs.getString(emailOrUniqueId, null)
+        Pair(emailOrUniqueId, resolvedId)
       } else {
-        // If it's a uniqueId, remove it directly.
-        prefs.edit().remove(emailOrUniqueId).apply()
+        val resolvedEmail = prefs.getString(emailOrUniqueId, null)
+        Pair(resolvedEmail, emailOrUniqueId)
       }
+
+      val editor = prefs.edit()
+      email?.let { editor.remove(it) }
+      uniqueId?.let {
+        editor.remove(it)
+        editor.remove("${uniqueId}_scopes")
+      }
+      editor.remove("last_signed_in_user_id")
+      editor.apply()
     } catch (e: Exception) {
       // Silently ignore
     }

--- a/android/src/main/java/com/nitrogooglesignin/GoogleSignInController.kt
+++ b/android/src/main/java/com/nitrogooglesignin/GoogleSignInController.kt
@@ -34,6 +34,7 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.google.android.gms.auth.api.identity.Identity
 import com.google.android.gms.auth.api.identity.RevokeAccessRequest
+import com.google.android.gms.common.api.Scope
 
 internal object GoogleSignInController {
   private var webClientId: String? = null
@@ -147,6 +148,7 @@ internal object GoogleSignInController {
     val account = Account(email, "com.google")
     val request = RevokeAccessRequest.builder()
       .setAccount(account)
+      .setScopes(emptyList<Scope>())
       .build()
 
     try {

--- a/example-expo/App.tsx
+++ b/example-expo/App.tsx
@@ -11,14 +11,39 @@ import {
 import {
   GoogleOneTapSignIn,
   GoogleSignInButton,
+  isCancelledResponse,
+  isErrorWithCode,
   isNoSavedCredentialFoundResponse,
   isSuccessResponse,
+  statusCodes,
   type OneTapSuccessData,
 } from 'react-native-nitro-google-signin'
 
 const DRIVE_FULL_SCOPE = 'https://www.googleapis.com/auth/drive'
 
 const WEB_CLIENT_ID = process.env.EXPO_PUBLIC_WEB_CLIENT_ID ?? ''
+
+function formatGoogleSignInError(error: unknown, fallback: string): string {
+  if (isErrorWithCode(error)) {
+    return `${error.code}: ${error.message}`
+  }
+  if (error instanceof Error) {
+    return error.message
+  }
+  return fallback
+}
+
+function formatSignInResponse(
+  response: Awaited<ReturnType<typeof GoogleOneTapSignIn.createAccount>>
+): string {
+  if (isCancelledResponse(response)) {
+    return `${statusCodes.SIGN_IN_CANCELLED}: Sign-in cancelled`
+  }
+  if (isNoSavedCredentialFoundResponse(response)) {
+    return 'No saved Google account found'
+  }
+  return 'Sign-in did not complete'
+}
 
 export default function App() {
   const [status, setStatus] = useState('Sign in below (Expo dev build)')
@@ -40,7 +65,7 @@ export default function App() {
   }
 
   const onSignInError = (e: unknown) => {
-    setStatus(e instanceof Error ? e.message : 'Sign-in failed')
+    setStatus(formatGoogleSignInError(e, 'Sign-in failed'))
   }
 
   const chooseAnotherAccount = async () => {
@@ -56,10 +81,10 @@ export default function App() {
       if (isSuccessResponse(response)) {
         onSignInSuccess(response.data)
       } else {
-        setStatus('Sign-in cancelled')
+        setStatus(formatSignInResponse(response))
       }
     } catch (e) {
-      setStatus(e instanceof Error ? e.message : 'Account selection failed')
+      setStatus(formatGoogleSignInError(e, 'Account selection failed'))
     } finally {
       setLoading(false)
     }
@@ -72,7 +97,7 @@ export default function App() {
     }
 
     setLoading(true)
-    setExtraScopesStatus('Requesting calendar read access…')
+    setExtraScopesStatus('Requesting Drive full access…')
     try {
       const result = await GoogleOneTapSignIn.requestScopes([DRIVE_FULL_SCOPE])
       if (result.serverAuthCode) {
@@ -86,7 +111,7 @@ export default function App() {
       }
     } catch (e) {
       setExtraScopesStatus(
-        e instanceof Error ? e.message : 'Failed to request scopes'
+        formatGoogleSignInError(e, 'Failed to request scopes')
       )
     } finally {
       setLoading(false)
@@ -102,7 +127,7 @@ export default function App() {
       setExtraScopesStatus(null)
       setStatus('Signed out')
     } catch (e) {
-      setStatus(e instanceof Error ? e.message : 'Sign out failed')
+      setStatus(formatGoogleSignInError(e, 'Sign out failed'))
     } finally {
       setLoading(false)
     }
@@ -117,8 +142,7 @@ export default function App() {
       setExtraScopesStatus(null)
       setStatus('Access revoked')
     } catch (e) {
-      setStatus(e instanceof Error ? e.message : 'Revoke access failed')
-      console.log('revokeAccess error', e)
+      setStatus(formatGoogleSignInError(e, 'Revoke access failed'))
     } finally {
       setLoading(false)
     }

--- a/example-expo/App.tsx
+++ b/example-expo/App.tsx
@@ -16,8 +16,7 @@ import {
   type OneTapSuccessData,
 } from 'react-native-nitro-google-signin'
 
-const CALENDAR_READONLY_SCOPE =
-  'https://www.googleapis.com/auth/calendar.readonly'
+const DRIVE_FULL_SCOPE = 'https://www.googleapis.com/auth/drive'
 
 const WEB_CLIENT_ID = process.env.EXPO_PUBLIC_WEB_CLIENT_ID ?? ''
 
@@ -75,9 +74,7 @@ export default function App() {
     setLoading(true)
     setExtraScopesStatus('Requesting calendar read access…')
     try {
-      const result = await GoogleOneTapSignIn.requestScopes([
-        CALENDAR_READONLY_SCOPE,
-      ])
+      const result = await GoogleOneTapSignIn.requestScopes([DRIVE_FULL_SCOPE])
       if (result.serverAuthCode) {
         setExtraScopesStatus(
           `Scope granted. Server auth code received (${result.serverAuthCode.slice(0, 12)}…).`
@@ -106,6 +103,22 @@ export default function App() {
       setStatus('Signed out')
     } catch (e) {
       setStatus(e instanceof Error ? e.message : 'Sign out failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const revokeAccess = async () => {
+    try {
+      setLoading(true)
+      setStatus('Revoking access…')
+      await GoogleOneTapSignIn.revokeAccess(user?.user.id ?? '')
+      setUser(null)
+      setExtraScopesStatus(null)
+      setStatus('Access revoked')
+    } catch (e) {
+      setStatus(e instanceof Error ? e.message : 'Revoke access failed')
+      console.log('revokeAccess error', e)
     } finally {
       setLoading(false)
     }
@@ -164,7 +177,7 @@ export default function App() {
               onPress={loading ? undefined : requestAdditionalScopes}
               style={[styles.action, loading && styles.actionDisabled]}
             >
-              Request calendar read access
+              Request drive full access
             </Text>
             <Text
               accessibilityRole="button"
@@ -172,6 +185,13 @@ export default function App() {
               style={[styles.action, loading && styles.actionDisabled]}
             >
               Sign out
+            </Text>
+            <Text
+              accessibilityRole="button"
+              onPress={loading ? undefined : revokeAccess}
+              style={[styles.action, loading && styles.actionDisabled]}
+            >
+              Revoke access
             </Text>
           </View>
         )}

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -10,15 +10,40 @@ import {
 import {
   GoogleOneTapSignIn,
   GoogleSignInButton,
+  isCancelledResponse,
+  isErrorWithCode,
   isNoSavedCredentialFoundResponse,
   isSuccessResponse,
   OneTapSuccessData,
+  statusCodes,
 } from 'react-native-nitro-google-signin';
 import Config from 'react-native-config';
 
 const WEB_CLIENT_ID = Config.WEB_CLIENT_ID;
 
 const DRIVE_FULL_SCOPE = 'https://www.googleapis.com/auth/drive';
+
+function formatGoogleSignInError(error: unknown, fallback: string): string {
+  if (isErrorWithCode(error)) {
+    return `${error.code}: ${error.message}`;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return fallback;
+}
+
+function formatSignInResponse(
+  response: Awaited<ReturnType<typeof GoogleOneTapSignIn.createAccount>>,
+): string {
+  if (isCancelledResponse(response)) {
+    return `${statusCodes.SIGN_IN_CANCELLED}: Sign-in cancelled`;
+  }
+  if (isNoSavedCredentialFoundResponse(response)) {
+    return 'No saved Google account found';
+  }
+  return 'Sign-in did not complete';
+}
 
 function App(): React.JSX.Element {
   const [status, setStatus] = useState<string>('Sign in below');
@@ -31,6 +56,7 @@ function App(): React.JSX.Element {
   useEffect(() => {
     GoogleOneTapSignIn.configure({
       webClientId: WEB_CLIENT_ID,
+      offlineAccess: true,
     });
   }, []);
 
@@ -40,7 +66,7 @@ function App(): React.JSX.Element {
   };
 
   const onSignInError = (e: unknown) => {
-    setStatus(e instanceof Error ? e.message : 'Sign-in failed');
+    setStatus(formatGoogleSignInError(e, 'Sign-in failed'));
   };
 
   const chooseAnotherAccount = async () => {
@@ -56,10 +82,10 @@ function App(): React.JSX.Element {
       if (isSuccessResponse(response)) {
         onSignInSuccess(response.data);
       } else {
-        setStatus('Sign-in cancelled');
+        setStatus(formatSignInResponse(response));
       }
     } catch (e) {
-      setStatus(e instanceof Error ? e.message : 'Account selection failed');
+      setStatus(formatGoogleSignInError(e, 'Account selection failed'));
     } finally {
       setLoading(false);
     }
@@ -72,11 +98,9 @@ function App(): React.JSX.Element {
     }
 
     setLoading(true);
-    setExtraScopesStatus('Requesting calendar read access…');
+    setExtraScopesStatus('Requesting Drive full access…');
     try {
       const result = await GoogleOneTapSignIn.requestScopes([DRIVE_FULL_SCOPE]);
-
-      console.log('result', result);
 
       if (result.serverAuthCode) {
         setExtraScopesStatus(
@@ -89,8 +113,9 @@ function App(): React.JSX.Element {
       }
     } catch (e) {
       setExtraScopesStatus(
-        e instanceof Error ? e.message : 'Failed to request scopes',
+        formatGoogleSignInError(e, 'Failed to request scopes'),
       );
+      console.log('requestAdditionalScopes error', e, (e as Error).name);
     } finally {
       setLoading(false);
     }
@@ -105,7 +130,7 @@ function App(): React.JSX.Element {
       setExtraScopesStatus(null);
       setStatus('Signed out');
     } catch (e) {
-      setStatus(e instanceof Error ? e.message : 'Sign out failed');
+      setStatus(formatGoogleSignInError(e, 'Sign out failed'));
     } finally {
       setLoading(false);
     }
@@ -120,8 +145,7 @@ function App(): React.JSX.Element {
       setExtraScopesStatus(null);
       setStatus('Access revoked');
     } catch (e) {
-      setStatus(e instanceof Error ? e.message : 'Revoke access failed');
-      console.log('revokeAccess error', e);
+      setStatus(formatGoogleSignInError(e, 'Revoke access failed'));
     } finally {
       setLoading(false);
     }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -18,8 +18,8 @@ import Config from 'react-native-config';
 
 const WEB_CLIENT_ID = Config.WEB_CLIENT_ID;
 
-const CALENDAR_READONLY_SCOPE =
-  'https://www.googleapis.com/auth/calendar.readonly';
+const DRIVE_FULL_SCOPE =
+  'https://www.googleapis.com/auth/drive';
 
 function App(): React.JSX.Element {
   const [status, setStatus] = useState<string>('Sign in below');
@@ -76,7 +76,7 @@ function App(): React.JSX.Element {
     setExtraScopesStatus('Requesting calendar read access…');
     try {
       const result = await GoogleOneTapSignIn.requestScopes([
-        CALENDAR_READONLY_SCOPE,
+        DRIVE_FULL_SCOPE,
       ]);
 
       if (result.serverAuthCode) {
@@ -107,6 +107,23 @@ function App(): React.JSX.Element {
       setStatus('Signed out');
     } catch (e) {
       setStatus(e instanceof Error ? e.message : 'Sign out failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const revokeAccess = async () => {
+    try {
+      setLoading(true);
+      setStatus('Revoking access…');
+      await GoogleOneTapSignIn.revokeAccess(user?.user.id ?? '');
+      setUser(null);
+      setExtraScopesStatus(null);
+      setStatus('Access revoked');
+    } catch (e) {
+      setStatus(e instanceof Error ? e.message : 'Revoke access failed');
+      console.log('revokeAccess error', e);
+      
     } finally {
       setLoading(false);
     }
@@ -163,7 +180,7 @@ function App(): React.JSX.Element {
             onPress={loading ? undefined : requestAdditionalScopes}
             style={[styles.action, loading && styles.actionDisabled]}
           >
-            Request calendar read access
+            Request drive full access
           </Text>
           <Text
             accessibilityRole="button"
@@ -171,6 +188,13 @@ function App(): React.JSX.Element {
             style={[styles.action, loading && styles.actionDisabled]}
           >
             Sign out
+          </Text>
+          <Text
+            accessibilityRole="button"
+            onPress={loading ? undefined : revokeAccess}
+            style={[styles.action, loading && styles.actionDisabled]}
+          >
+            Revoke access
           </Text>
         </View>
       )}

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -18,8 +18,7 @@ import Config from 'react-native-config';
 
 const WEB_CLIENT_ID = Config.WEB_CLIENT_ID;
 
-const DRIVE_FULL_SCOPE =
-  'https://www.googleapis.com/auth/drive';
+const DRIVE_FULL_SCOPE = 'https://www.googleapis.com/auth/drive';
 
 function App(): React.JSX.Element {
   const [status, setStatus] = useState<string>('Sign in below');
@@ -75,9 +74,9 @@ function App(): React.JSX.Element {
     setLoading(true);
     setExtraScopesStatus('Requesting calendar read access…');
     try {
-      const result = await GoogleOneTapSignIn.requestScopes([
-        DRIVE_FULL_SCOPE,
-      ]);
+      const result = await GoogleOneTapSignIn.requestScopes([DRIVE_FULL_SCOPE]);
+
+      console.log('result', result);
 
       if (result.serverAuthCode) {
         setExtraScopesStatus(
@@ -123,7 +122,6 @@ function App(): React.JSX.Element {
     } catch (e) {
       setStatus(e instanceof Error ? e.message : 'Revoke access failed');
       console.log('revokeAccess error', e);
-      
     } finally {
       setLoading(false);
     }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -62,7 +62,7 @@ PODS:
   - hermes-engine (250829098.0.14):
     - hermes-engine/Pre-built (= 250829098.0.14)
   - hermes-engine/Pre-built (250829098.0.14)
-  - NitroGoogleSignin (0.8.0):
+  - NitroGoogleSignin (0.8.1):
     - GoogleSignIn (< 9.2.0, ~> 9.0)
     - hermes-engine
     - NitroModules
@@ -2293,86 +2293,86 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 77880c98268570c547adcad251253b3187c9457b
-  NitroGoogleSignin: 76a679ee6e551aff839baf289dd9b01bac9be2a9
-  NitroModules: 16bc17a076b12304d608f7c915b9d321f56dfc19
+  NitroGoogleSignin: 493786259fc963c5f4be4648accc3f6bfcaa6642
+  NitroModules: 8308314b644c15567ffad50bb10667e8c1d82666
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
   RCTRequired: 30451112e6fef4e6f31b4e7eee0845156e35e4b0
   RCTSwiftUI: 5aaf0b07e747ba749dc6acc94d8bd41eea4b570f
-  RCTSwiftUIWrapper: ab2ca548be15d63afa95103afc8685a7c3eab78b
+  RCTSwiftUIWrapper: 1feaf484029fd6294fe8bc401d28e1d803eca142
   RCTTypeSafety: 3eaed17dbddb0b989208b062ea14c44d412b9780
   React: 2574546f2d017abd14d0c9b48cf2b6a0547c2591
   React-callinvoker: 03cd4b931d1d583d87aae99b8f7b6fe26bf571ee
-  React-Core: 1c824d9c7dd8aa760b5f1b50d5a54c2a3f598f87
+  React-Core: b0a0038e05720fb8148759404e9c354e3e60043c
   React-Core-prebuilt: 13924a267683b3d6fa4bde9c80380becf83a9c5c
-  React-CoreModules: 2f9ed75bca7f6dea2b70e8a1f4a5ca9b6be52d76
-  React-cxxreact: 7103d5ba69848c039e11079e74ceede05efe795e
+  React-CoreModules: a1121b3182200be11e078940159c67ff95ee98b4
+  React-cxxreact: 8f74977959064bee99af63bb0ad95b6c3dbec921
   React-debug: 8cc8d99ccc664ef9e873027f7fc3fb0a50496012
-  React-defaultsnativemodule: 603c108411d39d7bb5ccb8c270f1f50cb6207e10
-  React-domnativemodule: c49a502edc85f515a029c341fe5fba155fa6675c
-  React-Fabric: acc4915d719db793c5853e5c74b54ea5aa48e865
-  React-FabricComponents: aebebc98914a4a8fc962fa7b5b98ebaf250acb68
-  React-FabricImage: 42e99e48ff73c8b20cee229e622977d0b97b6247
-  React-featureflags: c6d8d8d52acf3a956485726076b73eeff7935340
-  React-featureflagsnativemodule: c992de92dcf30dcf09efdec17752abe4128ec55f
-  React-graphics: 239fd9b0512e539d3563f0825618f4e49795eefd
-  React-hermes: ae4685ca9fa5f47003bc594d3f146e29284136d1
-  React-idlecallbacksnativemodule: 10a5be842ab181953c772a3f28cdf94572833eb0
-  React-ImageManager: c36a56c3b13eba92e1d0d30da35d0a1ccf29cd6c
-  React-intersectionobservernativemodule: 71404bfa47d31e4143cc9db3e26178b5cfcd07e1
-  React-jserrorhandler: ca2eeb03c1a77bbfab1b5425b943e3e8d92295f2
-  React-jsi: c4b6daf8a31ac54f2db49cd6cce29720fec1f3a8
-  React-jsiexecutor: acdc1a217b7ea29bcf6315b770d01e6b1c2fca14
-  React-jsinspector: 95d6394efe9fb4a64ed33afc076b32a6384c8514
-  React-jsinspectorcdp: 6ce51378a552feaaaac1a7b0d995fa0c49fa4f8c
-  React-jsinspectornetwork: 0db435c9264f200635fdf294a3b643dd3946d4cf
-  React-jsinspectortracing: 2e4470e1f301ff597bd65299aa95da4bae6e5c4f
-  React-jsitooling: 796bc991cdce68e2cc059d0271a28e0d4f8b0891
-  React-jsitracing: f3008e7b5e1d9de8d9f2ca1b85824ed86b0cea00
-  React-logger: fff73f4ceecad968c97baafdc77dcf84befc38b6
-  React-Mapbuffer: ce449ccdf3b80384415b925606be8a4bdcfc65d3
-  React-microtasksnativemodule: 2eb3f49d0d8e77b5343455eccd057010b8d38b6b
-  React-mutationobservernativemodule: f0a0d5ae9b51caf7becbeabf836d716cfedb6bf2
-  react-native-config: 6188f674e4f4b3bdfd43c22886fb04f3103793ff
-  react-native-safe-area-context: fb5c8ee9f6dd62ef710611b3d370c501f42a4ac0
-  React-NativeModulesApple: a092d89b58f635ebfab88048b0eda9fb516819fd
-  React-networking: 968bbbe73590149feb1e72b2af4f6a68e4796ece
+  React-defaultsnativemodule: 7c8182addbb79ec576c589186b51e3fb405da7da
+  React-domnativemodule: 576bd1e6ad81477997dcb556e6db1f005134356b
+  React-Fabric: 4cbd22315ddb9e33441437f851117d314d1b4ad3
+  React-FabricComponents: efe374aecaf1bbc2fb9a195ece4b50fd9f66bfa0
+  React-FabricImage: cfeffc0b527de8bc2dc5a50618dad119361d0ec3
+  React-featureflags: 98931b22f5f4b861a3985b75bd79c5fcbe4618ab
+  React-featureflagsnativemodule: 518c2e279cdb3835604f7e8fb15f4c2691336b4c
+  React-graphics: ac9ff09da733d98c0e5eddb589dc7f9f082c9531
+  React-hermes: bd1a14a982e63ee75e9c9cb8d11d3d4b5f330196
+  React-idlecallbacksnativemodule: b6378d3bca83d8284e1abaa51251ee1ce570d85a
+  React-ImageManager: 4936349da191d1bc29ed2bbaf5a2dd74bfdf5ed8
+  React-intersectionobservernativemodule: d9a6451f2aa1f1c989d5d5e0d967db2c07d0c48c
+  React-jserrorhandler: 2455567e21fcc036f96015b2b8eb4eb13e0d8d05
+  React-jsi: bf5ec8e7a7b26bddc39ab7f821af5aad8bb94a33
+  React-jsiexecutor: cf6c957f578dd491ec8ae516a39aff2cf7369f1a
+  React-jsinspector: 63e9b9f9a5b6c51bf38deea2b379a63754c0ab0d
+  React-jsinspectorcdp: 327082854cdebb1f500a669c51146b9fd871058c
+  React-jsinspectornetwork: bbc5c2e881252075d63dc679f18cd856c2def94e
+  React-jsinspectortracing: ea6ec857ead0de4e6bbb2e12ee48ae4381938874
+  React-jsitooling: 52e278666b35e856414d613d7dc50d1f0d50d9a5
+  React-jsitracing: 642172314677a1d1780b81f4e2e4a3f4d3ccf238
+  React-logger: 35cda3ab8977c6c4546e3cf6dc8f91bacec25934
+  React-Mapbuffer: c058c051f571589e37a29bce18d0e9b730faa9d0
+  React-microtasksnativemodule: 03752e60738a797bb49f4d6cb0291dfa398099b8
+  React-mutationobservernativemodule: 2e568e13c98bd185fe83266795233fa7ad2cbc19
+  react-native-config: 93721be89c97d983d5a90e2f3e692c8ff1d95720
+  react-native-safe-area-context: c1eb308f4b36372a4de4b3bdaa8ed695ec3dd461
+  React-NativeModulesApple: a4713821c9caae40ae33eef933a6e692a6f4a81d
+  React-networking: b344a1a41a4729ef859123b7a234f3092761cb25
   React-oscompat: 0b72a7e926954a0415ccd83e0748b6561fe45367
-  React-perflogger: 865984e492514aa6e5279fc3e663132cfa4d5022
-  React-performancecdpmetrics: 2efbf9bdb48c8d8446f4dd10e8bf0dc5d711772f
-  React-performancetimeline: 9d256484bff1513481be9f234baba694dc3b52e2
+  React-perflogger: a0d581c6cc174e847877107ddac3f4fc9b518dc7
+  React-performancecdpmetrics: 91d3d0dce2e3a239ea68cc2882e75b11a61cbf2e
+  React-performancetimeline: 4b9e04002c1ddba95167276a86424e5face65605
   React-RCTActionSheet: 902c79deec52f99cc48b1051b59bcbe86787d339
-  React-RCTAnimation: 09cf722039ae30ff5d64e2b011ff054ae651c3b6
-  React-RCTAppDelegate: a47de6fddb7eb0c028abba83138a5ce283bd7e77
-  React-RCTBlob: 38c418d067e0c61818223503063310122e44c588
-  React-RCTFabric: 480ca2a105730e1790cfd13291d086cb53725825
-  React-RCTFBReactNativeSpec: 63131378510a5191515a4adfc308e65b465106f4
-  React-RCTImage: 3ce36f82441b76b715818ee7ee95f6f5b34f9ee1
-  React-RCTLinking: 2f7b5ed4983122e5115732d25a4360960eab583c
-  React-RCTNetwork: dcd3b180f33da86f5dc5e928a816eb5464fa7f16
-  React-RCTRuntime: 6ef8e778fbab426b12eb5a9b5f7a0e86313c5a10
-  React-RCTSettings: b97727ec8c55c35bd284457a647c938c040b942b
-  React-RCTText: 4d1b88f6d3e1a43afe46706d956ec6664c87b984
-  React-RCTVibration: 415d14d6a1a64bf947fcef6b193915a494431168
+  React-RCTAnimation: f50eac1c9dbea36c4abc69cb24e2da4364374055
+  React-RCTAppDelegate: a5d746fec869d15a8f6eecce60510c18e52135d5
+  React-RCTBlob: e544dc72edc6f277c67e85493b0a405e1993c250
+  React-RCTFabric: 8003ea99830c294857d41469a888b033e5ad91a6
+  React-RCTFBReactNativeSpec: 8a3506041284fdc75da90e6fa40fb9b575414a39
+  React-RCTImage: fb85496986a53d9e11a835124a083b7c7c33f898
+  React-RCTLinking: b8eafcdedaebf981a18396db61d1190f5279ea81
+  React-RCTNetwork: 03573c4fcc73e28f48fea7aea69310b6955a749c
+  React-RCTRuntime: 08d58920b217b2d7715d5da595794e63520cd2d9
+  React-RCTSettings: f9b278b46e5de1ff8b843bb7aefaee721f06572d
+  React-RCTText: 7266943febf3382dac8adce9ba0de95b90c26e9e
+  React-RCTVibration: 27e1952701ec858922062f25a59b0c48e7153151
   React-rendererconsistency: ef8519bdd9931261c6561bfad6506356b8108387
-  React-renderercss: 1aa1bf99fa2ace143eb87d5190fd43609fc1e832
-  React-rendererdebug: 40a4fb3dea21a7ac1759ca0eb6c88a924aecb075
-  React-RuntimeApple: 84fadbb4fe8ca531e15e29a22af05911f17569c6
-  React-RuntimeCore: f4d9af5f16d37e63308cb03b36c89d01e7f68a06
-  React-runtimeexecutor: 4d59410f66af529d04c84c8b152ced07dabc471e
-  React-RuntimeHermes: fd719d8f4d9ce79636fe2e09e94b0ac31b7b263b
-  React-runtimescheduler: 784033620aa5515e2f45a60369eed4d32f9400b8
-  React-timing: a16df9ae98f950396d9ce3abf43cb0cb2f21194c
-  React-utils: b68ee619aef28d8f9b85532d98db0327f7bdf743
-  React-viewtransitionnativemodule: 11fe091101d381451b1542c37b2745900254f096
-  React-webperformancenativemodule: b5d249419f1546663845c82f24de4e18a3180997
-  ReactAppDependencyProvider: dcdd0e1b9559a6d8d8aea05286f4ed085091978e
-  ReactCodegen: 1973e629fe2614a7b2cf72919cb9935b6c34675f
-  ReactCommon: d5c1bb4427bf51c443de5926aac332c89ddd9363
+  React-renderercss: edc1b0a18b12d681f8edbc779039dc6db32cf7b2
+  React-rendererdebug: 074ec3420f3bab2bea498da65e5a17e9288c90d0
+  React-RuntimeApple: 180682587e82ae4fc525f7d6636ed5db39c1e78c
+  React-RuntimeCore: 991cdb27072f7885750fdad4a70c2b919533e4ef
+  React-runtimeexecutor: bfec6ca5e62c6b2460a4adf0fddce0c4db0a8748
+  React-RuntimeHermes: dcb07afe0f38c1cbaf48b7a1bf4904e867529726
+  React-runtimescheduler: fdf0b71e519e416ad38c76525df43eba8dd78db2
+  React-timing: 7b538f379678210bf30d8541eb4cf007c000c6f3
+  React-utils: a15da1da76aee3dd0ed9f51d62bf1c09be17c221
+  React-viewtransitionnativemodule: 8556c844dcd691ab3fe1b32bbf8f58c8c9a49c75
+  React-webperformancenativemodule: 4d1d0258107fe0cb8ef5c9ac17a6a099785f2995
+  ReactAppDependencyProvider: adf5403892170fbe996fce485a703f25df08db66
+  ReactCodegen: db8e2836b82f6f4c3ef1463cb6f6cd61a25b8cc8
+  ReactCommon: 4d01bfb533b93a2103329dfefc74db6a9e272888
   ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   Yoga: fe50ab299e578f397fef753cf309c6703a4db29b
 
 PODFILE CHECKSUM: caf2c0fbef2ed7f289b9be7f70370842f53f7073
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2293,86 +2293,86 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 77880c98268570c547adcad251253b3187c9457b
-  NitroGoogleSignin: 493786259fc963c5f4be4648accc3f6bfcaa6642
-  NitroModules: 8308314b644c15567ffad50bb10667e8c1d82666
+  NitroGoogleSignin: 495889306c08082e2e080f2980a6cd6079e96bc2
+  NitroModules: 16bc17a076b12304d608f7c915b9d321f56dfc19
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
   RCTRequired: 30451112e6fef4e6f31b4e7eee0845156e35e4b0
   RCTSwiftUI: 5aaf0b07e747ba749dc6acc94d8bd41eea4b570f
-  RCTSwiftUIWrapper: 1feaf484029fd6294fe8bc401d28e1d803eca142
+  RCTSwiftUIWrapper: ab2ca548be15d63afa95103afc8685a7c3eab78b
   RCTTypeSafety: 3eaed17dbddb0b989208b062ea14c44d412b9780
   React: 2574546f2d017abd14d0c9b48cf2b6a0547c2591
   React-callinvoker: 03cd4b931d1d583d87aae99b8f7b6fe26bf571ee
-  React-Core: b0a0038e05720fb8148759404e9c354e3e60043c
+  React-Core: 1c824d9c7dd8aa760b5f1b50d5a54c2a3f598f87
   React-Core-prebuilt: 13924a267683b3d6fa4bde9c80380becf83a9c5c
-  React-CoreModules: a1121b3182200be11e078940159c67ff95ee98b4
-  React-cxxreact: 8f74977959064bee99af63bb0ad95b6c3dbec921
+  React-CoreModules: 2f9ed75bca7f6dea2b70e8a1f4a5ca9b6be52d76
+  React-cxxreact: 7103d5ba69848c039e11079e74ceede05efe795e
   React-debug: 8cc8d99ccc664ef9e873027f7fc3fb0a50496012
-  React-defaultsnativemodule: 7c8182addbb79ec576c589186b51e3fb405da7da
-  React-domnativemodule: 576bd1e6ad81477997dcb556e6db1f005134356b
-  React-Fabric: 4cbd22315ddb9e33441437f851117d314d1b4ad3
-  React-FabricComponents: efe374aecaf1bbc2fb9a195ece4b50fd9f66bfa0
-  React-FabricImage: cfeffc0b527de8bc2dc5a50618dad119361d0ec3
-  React-featureflags: 98931b22f5f4b861a3985b75bd79c5fcbe4618ab
-  React-featureflagsnativemodule: 518c2e279cdb3835604f7e8fb15f4c2691336b4c
-  React-graphics: ac9ff09da733d98c0e5eddb589dc7f9f082c9531
-  React-hermes: bd1a14a982e63ee75e9c9cb8d11d3d4b5f330196
-  React-idlecallbacksnativemodule: b6378d3bca83d8284e1abaa51251ee1ce570d85a
-  React-ImageManager: 4936349da191d1bc29ed2bbaf5a2dd74bfdf5ed8
-  React-intersectionobservernativemodule: d9a6451f2aa1f1c989d5d5e0d967db2c07d0c48c
-  React-jserrorhandler: 2455567e21fcc036f96015b2b8eb4eb13e0d8d05
-  React-jsi: bf5ec8e7a7b26bddc39ab7f821af5aad8bb94a33
-  React-jsiexecutor: cf6c957f578dd491ec8ae516a39aff2cf7369f1a
-  React-jsinspector: 63e9b9f9a5b6c51bf38deea2b379a63754c0ab0d
-  React-jsinspectorcdp: 327082854cdebb1f500a669c51146b9fd871058c
-  React-jsinspectornetwork: bbc5c2e881252075d63dc679f18cd856c2def94e
-  React-jsinspectortracing: ea6ec857ead0de4e6bbb2e12ee48ae4381938874
-  React-jsitooling: 52e278666b35e856414d613d7dc50d1f0d50d9a5
-  React-jsitracing: 642172314677a1d1780b81f4e2e4a3f4d3ccf238
-  React-logger: 35cda3ab8977c6c4546e3cf6dc8f91bacec25934
-  React-Mapbuffer: c058c051f571589e37a29bce18d0e9b730faa9d0
-  React-microtasksnativemodule: 03752e60738a797bb49f4d6cb0291dfa398099b8
-  React-mutationobservernativemodule: 2e568e13c98bd185fe83266795233fa7ad2cbc19
-  react-native-config: 93721be89c97d983d5a90e2f3e692c8ff1d95720
-  react-native-safe-area-context: c1eb308f4b36372a4de4b3bdaa8ed695ec3dd461
-  React-NativeModulesApple: a4713821c9caae40ae33eef933a6e692a6f4a81d
-  React-networking: b344a1a41a4729ef859123b7a234f3092761cb25
+  React-defaultsnativemodule: 603c108411d39d7bb5ccb8c270f1f50cb6207e10
+  React-domnativemodule: c49a502edc85f515a029c341fe5fba155fa6675c
+  React-Fabric: acc4915d719db793c5853e5c74b54ea5aa48e865
+  React-FabricComponents: aebebc98914a4a8fc962fa7b5b98ebaf250acb68
+  React-FabricImage: 42e99e48ff73c8b20cee229e622977d0b97b6247
+  React-featureflags: c6d8d8d52acf3a956485726076b73eeff7935340
+  React-featureflagsnativemodule: c992de92dcf30dcf09efdec17752abe4128ec55f
+  React-graphics: 239fd9b0512e539d3563f0825618f4e49795eefd
+  React-hermes: ae4685ca9fa5f47003bc594d3f146e29284136d1
+  React-idlecallbacksnativemodule: 10a5be842ab181953c772a3f28cdf94572833eb0
+  React-ImageManager: c36a56c3b13eba92e1d0d30da35d0a1ccf29cd6c
+  React-intersectionobservernativemodule: 71404bfa47d31e4143cc9db3e26178b5cfcd07e1
+  React-jserrorhandler: ca2eeb03c1a77bbfab1b5425b943e3e8d92295f2
+  React-jsi: c4b6daf8a31ac54f2db49cd6cce29720fec1f3a8
+  React-jsiexecutor: acdc1a217b7ea29bcf6315b770d01e6b1c2fca14
+  React-jsinspector: 95d6394efe9fb4a64ed33afc076b32a6384c8514
+  React-jsinspectorcdp: 6ce51378a552feaaaac1a7b0d995fa0c49fa4f8c
+  React-jsinspectornetwork: 0db435c9264f200635fdf294a3b643dd3946d4cf
+  React-jsinspectortracing: 2e4470e1f301ff597bd65299aa95da4bae6e5c4f
+  React-jsitooling: 796bc991cdce68e2cc059d0271a28e0d4f8b0891
+  React-jsitracing: f3008e7b5e1d9de8d9f2ca1b85824ed86b0cea00
+  React-logger: fff73f4ceecad968c97baafdc77dcf84befc38b6
+  React-Mapbuffer: ce449ccdf3b80384415b925606be8a4bdcfc65d3
+  React-microtasksnativemodule: 2eb3f49d0d8e77b5343455eccd057010b8d38b6b
+  React-mutationobservernativemodule: f0a0d5ae9b51caf7becbeabf836d716cfedb6bf2
+  react-native-config: 6188f674e4f4b3bdfd43c22886fb04f3103793ff
+  react-native-safe-area-context: fb5c8ee9f6dd62ef710611b3d370c501f42a4ac0
+  React-NativeModulesApple: a092d89b58f635ebfab88048b0eda9fb516819fd
+  React-networking: 968bbbe73590149feb1e72b2af4f6a68e4796ece
   React-oscompat: 0b72a7e926954a0415ccd83e0748b6561fe45367
-  React-perflogger: a0d581c6cc174e847877107ddac3f4fc9b518dc7
-  React-performancecdpmetrics: 91d3d0dce2e3a239ea68cc2882e75b11a61cbf2e
-  React-performancetimeline: 4b9e04002c1ddba95167276a86424e5face65605
+  React-perflogger: 865984e492514aa6e5279fc3e663132cfa4d5022
+  React-performancecdpmetrics: 2efbf9bdb48c8d8446f4dd10e8bf0dc5d711772f
+  React-performancetimeline: 9d256484bff1513481be9f234baba694dc3b52e2
   React-RCTActionSheet: 902c79deec52f99cc48b1051b59bcbe86787d339
-  React-RCTAnimation: f50eac1c9dbea36c4abc69cb24e2da4364374055
-  React-RCTAppDelegate: a5d746fec869d15a8f6eecce60510c18e52135d5
-  React-RCTBlob: e544dc72edc6f277c67e85493b0a405e1993c250
-  React-RCTFabric: 8003ea99830c294857d41469a888b033e5ad91a6
-  React-RCTFBReactNativeSpec: 8a3506041284fdc75da90e6fa40fb9b575414a39
-  React-RCTImage: fb85496986a53d9e11a835124a083b7c7c33f898
-  React-RCTLinking: b8eafcdedaebf981a18396db61d1190f5279ea81
-  React-RCTNetwork: 03573c4fcc73e28f48fea7aea69310b6955a749c
-  React-RCTRuntime: 08d58920b217b2d7715d5da595794e63520cd2d9
-  React-RCTSettings: f9b278b46e5de1ff8b843bb7aefaee721f06572d
-  React-RCTText: 7266943febf3382dac8adce9ba0de95b90c26e9e
-  React-RCTVibration: 27e1952701ec858922062f25a59b0c48e7153151
+  React-RCTAnimation: 09cf722039ae30ff5d64e2b011ff054ae651c3b6
+  React-RCTAppDelegate: a47de6fddb7eb0c028abba83138a5ce283bd7e77
+  React-RCTBlob: 38c418d067e0c61818223503063310122e44c588
+  React-RCTFabric: 480ca2a105730e1790cfd13291d086cb53725825
+  React-RCTFBReactNativeSpec: 63131378510a5191515a4adfc308e65b465106f4
+  React-RCTImage: 3ce36f82441b76b715818ee7ee95f6f5b34f9ee1
+  React-RCTLinking: 2f7b5ed4983122e5115732d25a4360960eab583c
+  React-RCTNetwork: dcd3b180f33da86f5dc5e928a816eb5464fa7f16
+  React-RCTRuntime: 6ef8e778fbab426b12eb5a9b5f7a0e86313c5a10
+  React-RCTSettings: b97727ec8c55c35bd284457a647c938c040b942b
+  React-RCTText: 4d1b88f6d3e1a43afe46706d956ec6664c87b984
+  React-RCTVibration: 415d14d6a1a64bf947fcef6b193915a494431168
   React-rendererconsistency: ef8519bdd9931261c6561bfad6506356b8108387
-  React-renderercss: edc1b0a18b12d681f8edbc779039dc6db32cf7b2
-  React-rendererdebug: 074ec3420f3bab2bea498da65e5a17e9288c90d0
-  React-RuntimeApple: 180682587e82ae4fc525f7d6636ed5db39c1e78c
-  React-RuntimeCore: 991cdb27072f7885750fdad4a70c2b919533e4ef
-  React-runtimeexecutor: bfec6ca5e62c6b2460a4adf0fddce0c4db0a8748
-  React-RuntimeHermes: dcb07afe0f38c1cbaf48b7a1bf4904e867529726
-  React-runtimescheduler: fdf0b71e519e416ad38c76525df43eba8dd78db2
-  React-timing: 7b538f379678210bf30d8541eb4cf007c000c6f3
-  React-utils: a15da1da76aee3dd0ed9f51d62bf1c09be17c221
-  React-viewtransitionnativemodule: 8556c844dcd691ab3fe1b32bbf8f58c8c9a49c75
-  React-webperformancenativemodule: 4d1d0258107fe0cb8ef5c9ac17a6a099785f2995
-  ReactAppDependencyProvider: adf5403892170fbe996fce485a703f25df08db66
-  ReactCodegen: db8e2836b82f6f4c3ef1463cb6f6cd61a25b8cc8
-  ReactCommon: 4d01bfb533b93a2103329dfefc74db6a9e272888
+  React-renderercss: 1aa1bf99fa2ace143eb87d5190fd43609fc1e832
+  React-rendererdebug: 40a4fb3dea21a7ac1759ca0eb6c88a924aecb075
+  React-RuntimeApple: 84fadbb4fe8ca531e15e29a22af05911f17569c6
+  React-RuntimeCore: f4d9af5f16d37e63308cb03b36c89d01e7f68a06
+  React-runtimeexecutor: 4d59410f66af529d04c84c8b152ced07dabc471e
+  React-RuntimeHermes: fd719d8f4d9ce79636fe2e09e94b0ac31b7b263b
+  React-runtimescheduler: 784033620aa5515e2f45a60369eed4d32f9400b8
+  React-timing: a16df9ae98f950396d9ce3abf43cb0cb2f21194c
+  React-utils: b68ee619aef28d8f9b85532d98db0327f7bdf743
+  React-viewtransitionnativemodule: 11fe091101d381451b1542c37b2745900254f096
+  React-webperformancenativemodule: b5d249419f1546663845c82f24de4e18a3180997
+  ReactAppDependencyProvider: dcdd0e1b9559a6d8d8aea05286f4ed085091978e
+  ReactCodegen: 1973e629fe2614a7b2cf72919cb9935b6c34675f
+  ReactCommon: d5c1bb4427bf51c443de5926aac332c89ddd9363
   ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   Yoga: fe50ab299e578f397fef753cf309c6703a4db29b
 
 PODFILE CHECKSUM: caf2c0fbef2ed7f289b9be7f70370842f53f7073
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-google-signin",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "High-Performance Google Sign-In for React Native (Nitro Powered)",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index.js",

--- a/skills/react-native-nitro-google-signin/SKILL.md
+++ b/skills/react-native-nitro-google-signin/SKILL.md
@@ -33,6 +33,7 @@ Requires RN ≥ 0.76. **Not Expo Go** — use `expo-dev-client`.
 | ----- | ---- |
 | API | `GoogleOneTapSignIn` from `react-native-nitro-google-signin` |
 | Configure first | `GoogleOneTapSignIn.configure({ webClientId })` before sign-in |
+| `serverAuthCode` | Requires `offlineAccess: true` in `configure()` — otherwise always `null` |
 | Flow order | `checkPlayServices` → `signIn` → `createAccount` → `presentExplicitSignIn` |
 | Android `autoDetect` | Needs `google-services.json` + `com.google.gms.google-services` plugin |
 | iOS | `GoogleService-Info.plist` + `REVERSED_CLIENT_ID` URL scheme |

--- a/skills/react-native-nitro-google-signin/examples.md
+++ b/skills/react-native-nitro-google-signin/examples.md
@@ -22,6 +22,8 @@ await GoogleOneTapSignIn.signOut()
 
 ## Extra scopes
 
+`offlineAccess: true` in `configure()` is **required** for a non-null `serverAuthCode`:
+
 ```ts
 GoogleOneTapSignIn.configure({
   webClientId: 'YOUR_WEB_CLIENT_ID.apps.googleusercontent.com',

--- a/skills/react-native-nitro-google-signin/reference.md
+++ b/skills/react-native-nitro-google-signin/reference.md
@@ -19,7 +19,7 @@ Full types: https://react-native-nitro-google-sign-in.github.io/docs/guide/api-r
 | `presentExplicitSignIn()`        | Explicit Sign in with Google UI (Android dialog)                                                     |
 | `requestScopes(scopes)`          | `{ serverAuthCode }` after sign-in; needs `offlineAccess: true` in `configure()` for a non-null code |
 | `signOut()`                      | iOS GIDSignOut; Android disables auto sign-in semantics                                              |
-| `revokeAccess(id)`               | iOS disconnect; Android ≈ signOut                                                                    |
+| `revokeAccess(id)`               | Revokes app access / OAuth grant (iOS and Android)                                                   |
 
 ### Types
 

--- a/skills/react-native-nitro-google-signin/reference.md
+++ b/skills/react-native-nitro-google-signin/reference.md
@@ -17,7 +17,7 @@ Full types: https://react-native-nitro-google-sign-in.github.io/docs/guide/api-r
 | `signIn()`                       | Android: authorized CredMan accounts; iOS: current user or restore                                   |
 | `createAccount()`                | All accounts / interactive                                                                           |
 | `presentExplicitSignIn()`        | Explicit Sign in with Google UI (Android dialog)                                                     |
-| `requestScopes(scopes)`          | `{ serverAuthCode }` after sign-in; needs `offlineAccess: true` in `configure()` for a non-null code |
+| `requestScopes(scopes)`          | `{ serverAuthCode }` after sign-in; **`offlineAccess: true` in `configure()` required** for a non-null code |
 | `signOut()`                      | iOS GIDSignOut; Android disables auto sign-in semantics                                              |
 | `revokeAccess(id)`               | Revokes app access / OAuth grant (iOS and Android)                                                   |
 

--- a/src/GoogleOneTapSignIn.ts
+++ b/src/GoogleOneTapSignIn.ts
@@ -12,37 +12,85 @@ const hybrid =
 /**
  * Universal (One Tap) Google Sign-In for React Native on iOS and Android.
  *
+ * Call {@link configure} once before any other method.
+ *
  * @see https://react-native-nitro-google-sign-in.github.io/docs/guide/usage
  */
 export const GoogleOneTapSignIn = {
+  /**
+   * Configure Google Sign-In. Required before any other method.
+   *
+   * Set `offlineAccess: true` when your backend needs a `serverAuthCode`
+   * (from sign-in success or `requestScopes()`). Without it, `serverAuthCode` is always `null`.
+   */
   configure(params: OneTapConfigureParams): void {
     hybrid.configure(params)
   },
 
+  /**
+   * Validate Google Play Services on Android. Resolves immediately on iOS (no-op).
+   *
+   * @param showErrorResolutionDialog When `true` (default), show Google's resolution UI if Play Services can be updated.
+   * @throws {@link GoogleSignInError} with `PLAY_SERVICES_NOT_AVAILABLE` on Android when unavailable.
+   */
   checkPlayServices(showErrorResolutionDialog = true): Promise<void> {
     return hybrid.checkPlayServices(showErrorResolutionDialog)
   },
 
+  /**
+   * Low-friction sign-in without forcing the full account picker when possible.
+   *
+   * Android: Credential Manager with authorized accounts only.
+   * iOS: current user or `restorePreviousSignIn()`.
+   *
+   * User cancel is returned as `type: 'cancelled'`, not thrown.
+   */
   signIn(): Promise<OneTapResponse> {
     return hybrid.signIn()
   },
 
+  /**
+   * Interactive sign-in that can show all Google accounts on the device.
+   *
+   * Android: Credential Manager, all accounts.
+   * iOS: interactive `signIn(withPresenting:)`.
+   */
   createAccount(): Promise<OneTapResponse> {
     return hybrid.createAccount()
   },
 
+  /**
+   * Explicit **Sign in with Google** UI.
+   *
+   * Android: `GetSignInWithGoogleOption` account dialog.
+   * iOS: same interactive flow as {@link createAccount}.
+   */
   presentExplicitSignIn(): Promise<OneTapResponse> {
     return hybrid.presentExplicitSignIn()
   },
 
+  /**
+   * Request additional OAuth scopes after sign-in. User may see a consent screen.
+   *
+   * Requires an active signed-in session. **`configure({ offlineAccess: true })` is required**
+   * for a non-null `serverAuthCode` in the result.
+   *
+   * @param scopes Full OAuth scope URLs (not short names).
+   */
   requestScopes(scopes: string[]): Promise<OneTapAuthorizationResult> {
     return hybrid.requestScopes(scopes)
   },
 
+  /** Clear the Google Sign-In session in the native SDK. */
   signOut(): Promise<void> {
     return hybrid.signOut()
   },
 
+  /**
+   * Revoke app access / OAuth grant for the user.
+   *
+   * @param emailOrUniqueId User email or stable Google account id (`OneTapUser.id`).
+   */
   revokeAccess(emailOrUniqueId: string): Promise<void> {
     return hybrid.revokeAccess(emailOrUniqueId)
   },

--- a/src/specs/nitro-google-signin.nitro.ts
+++ b/src/specs/nitro-google-signin.nitro.ts
@@ -1,34 +1,70 @@
 import type { HybridObject } from 'react-native-nitro-modules'
 
+/** Discriminator for {@link OneTapResponse}. */
 export type OneTapResponseType =
   | 'success'
   | 'noSavedCredentialFound'
   | 'cancelled'
 
+/** Google account profile returned on successful sign-in. */
 export interface OneTapUser {
+  /** Stable Google account id (JWT `sub` / `uniqueId`). Prefer over email for primary keys. */
   id: string
+  /** Email address when available. */
   email: string | null
+  /** Full display name. */
   name: string | null
+  /** First name. */
   givenName: string | null
+  /** Last name. */
   familyName: string | null
+  /** Profile picture URL. */
   photo: string | null
 }
 
+/** Payload when a sign-in method returns `type: 'success'`. */
 export interface OneTapSuccessData {
   user: OneTapUser
+  /** OpenID Connect ID token (JWT). Verify on your backend with Google's keys. */
   idToken: string
+  /**
+   * OAuth 2.0 server auth code for your backend.
+   *
+   * **Requires `configure({ offlineAccess: true })`.** When `offlineAccess` is `false`
+   * (the default), this is always `null` — including after `requestScopes()`.
+   * Exchange the code on your backend for refresh tokens.
+   */
   serverAuthCode: string | null
 }
 
+/** Return value of `signIn()`, `createAccount()`, and `presentExplicitSignIn()`. */
 export interface OneTapResponse {
   type: OneTapResponseType
+  /** Non-null only when `type` is `'success'`. */
   data: OneTapSuccessData | null
 }
 
+/** Options for {@link GoogleOneTapSignIn.configure}. */
 export interface OneTapConfigureParams {
+  /**
+   * Web OAuth 2.0 client ID (`*.apps.googleusercontent.com`), or `'autoDetect'` to read
+   * from native config (Android `default_web_client_id`, iOS `WEB_CLIENT_ID` in plist).
+   */
   webClientId: string
+  /**
+   * iOS OAuth client ID for `GIDConfiguration.clientID`.
+   * **iOS:** required via this field or `GoogleService-Info.plist` `CLIENT_ID`. Ignored on Android.
+   */
   iosClientId?: string | null
+  /**
+   * Request offline access so sign-in and scope flows can return a `serverAuthCode`.
+   *
+   * **Required for any non-null `serverAuthCode`** on `OneTapSuccessData` and
+   * `OneTapAuthorizationResult`. Defaults to `false`; when `false`, `serverAuthCode`
+   * is always `null`.
+   */
   offlineAccess?: boolean
+  /** Restrict sign-in to a Google Workspace domain (e.g. `example.com`). */
   hostedDomain?: string | null
   /** SHA-256 hex nonce for the ID token. Auto-generated when omitted. */
   nonce?: string | null
@@ -41,10 +77,18 @@ export interface OneTapConfigureParams {
   autoSelectOnSignIn?: boolean
 }
 
+/** Return value of {@link GoogleOneTapSignIn.requestScopes}. */
 export interface OneTapAuthorizationResult {
+  /**
+   * OAuth 2.0 server auth code for the requested scopes.
+   *
+   * **Requires `configure({ offlineAccess: true })` before calling `requestScopes()`.**
+   * Without offline access, consent may succeed but this is `null`.
+   */
   serverAuthCode: string | null
 }
 
+/** Nitro hybrid backing {@link GoogleOneTapSignIn}. */
 export interface NitroGoogleSignin
   extends HybridObject<{ ios: 'swift'; android: 'kotlin' }> {
   configure(params: OneTapConfigureParams): void

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,29 +9,41 @@ export type {
   OneTapUser,
 } from './specs/nitro-google-signin.nitro'
 
-/** String literals for {@link OneTapResponseType} */
+/** String literals for {@link OneTapResponseType}. */
 export const OneTapResponseTypes = {
   success: 'success',
   noSavedCredentialFound: 'noSavedCredentialFound',
   cancelled: 'cancelled',
 } as const satisfies Record<string, OneTapResponseTypeLiteral>
 
+/** @internal Placeholder for API parity — sign-in methods take no arguments. */
 export type OneTapSignInParams = Record<string, never>
+/** @internal Placeholder for API parity — sign-in methods take no arguments. */
 export type OneTapCreateAccountParams = Record<string, never>
+/** @internal Placeholder for API parity — sign-in methods take no arguments. */
 export type OneTapExplicitSignInParams = Record<string, never>
 
+/** Error code strings thrown by native sign-in and authorization flows. */
 export const statusCodes = {
+  /** Credential Manager / Google Sign-In request failed (not user cancel). */
   ONE_TAP_START_FAILED: 'ONE_TAP_START_FAILED',
+  /** Android — Play Services missing or outdated. */
   PLAY_SERVICES_NOT_AVAILABLE: 'PLAY_SERVICES_NOT_AVAILABLE',
+  /** No Activity / view controller, or sign-in called before `configure()`. */
   IN_PROGRESS: 'IN_PROGRESS',
+  /** User must sign in first. */
   SIGN_IN_REQUIRED: 'SIGN_IN_REQUIRED',
+  /** User cancelled an authorization or sign-in flow. */
   SIGN_IN_CANCELLED: 'SIGN_IN_CANCELLED',
 } as const
 
 export type StatusCode = (typeof statusCodes)[keyof typeof statusCodes]
 
+/** Error thrown by native sign-in, Play Services checks, and authorization flows. */
 export class GoogleSignInError extends Error {
+  /** One of {@link statusCodes}. */
   code: StatusCode
+  /** Optional metadata (e.g. Play Services status on Android). */
   userInfo?: Record<string, string>
 
   constructor(
@@ -46,6 +58,20 @@ export class GoogleSignInError extends Error {
   }
 }
 
+/**
+ * Type guard for errors with a `code` and `message` (including native bridged errors).
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await GoogleOneTapSignIn.checkPlayServices()
+ * } catch (e) {
+ *   if (isErrorWithCode(e) && e.code === statusCodes.PLAY_SERVICES_NOT_AVAILABLE) {
+ *     // prompt user to update Play Services
+ *   }
+ * }
+ * ```
+ */
 export function isErrorWithCode(
   error: unknown
 ): error is Pick<GoogleSignInError, 'code' | 'message' | 'userInfo'> {
@@ -57,6 +83,16 @@ export function isErrorWithCode(
   )
 }
 
+/**
+ * Narrows a {@link OneTapResponse} to success with non-null `data`.
+ *
+ * @example
+ * ```ts
+ * if (isSuccessResponse(response)) {
+ *   const { user, idToken, serverAuthCode } = response.data
+ * }
+ * ```
+ */
 export function isSuccessResponse(
   response: import('./specs/nitro-google-signin.nitro').OneTapResponse
 ): response is import('./specs/nitro-google-signin.nitro').OneTapResponse & {
@@ -66,12 +102,14 @@ export function isSuccessResponse(
   return response.type === 'success' && response.data != null
 }
 
+/** `true` when the user has no saved Google credential for this app. */
 export function isNoSavedCredentialFoundResponse(
   response: import('./specs/nitro-google-signin.nitro').OneTapResponse
 ): boolean {
   return response.type === 'noSavedCredentialFound'
 }
 
+/** `true` when the user dismissed the sign-in UI (not thrown — check the response). */
 export function isCancelledResponse(
   response: import('./specs/nitro-google-signin.nitro').OneTapResponse
 ): boolean {

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,8 +48,13 @@ export class GoogleSignInError extends Error {
 
 export function isErrorWithCode(
   error: unknown
-): error is GoogleSignInError {
-  return error instanceof GoogleSignInError
+): error is Pick<GoogleSignInError, 'code' | 'message' | 'userInfo'> {
+  if (error instanceof GoogleSignInError) return true
+  if (typeof error !== 'object' || error === null) return false
+  const candidate = error as Partial<GoogleSignInError>
+  return (
+    typeof candidate.code === 'string' && typeof candidate.message === 'string'
+  )
 }
 
 export function isSuccessResponse(


### PR DESCRIPTION
## Summary

- Adds `androidx.security:security-crypto:1.1.0` to securely store mappings between the Google user ID (uniqueId) and the user's email.
- Stores the uniqueId-to-email mappings in `EncryptedSharedPreferences` on successful sign-in.
- Uses `Identity.getAuthorizationClient` in `revokeAccess()` to revoke the OAuth grant for the user, resolving the email from secure storage if needed.
- Calls `signOut()` to clear local credential state.
- Updates documentation (`README.md`, docs submodule files, and agent reference) to reflect Android support.

Fixes #31

## Test plan

- Checked compilation: JavaScript / TypeScript and Android native builds succeed.
- Built example app Kotlin code successfully with the new dependency.

## Docs

- Updated README, agent skill reference, and Docusaurus content files (`api-reference.md`, `usage.md`).