### PR TITLE
Security hardening from audit run-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,14 +297,14 @@ See [Usage — Access tokens](https://react-native-nitro-google-sign-in.github.i
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `configure(params)`       | Required before other calls. `webClientId` or `'autoDetect'`; optional `scopes`, `offlineAccess` (**required for `serverAuthCode`**), `hostedDomain`, `nonce`, `autoSelectOnSignIn`. |
 | `checkPlayServices()`     | Android: validates Play Services. iOS: no-op resolve.                                                                                            |
-| `signIn()`                | Silent / restore previous sign-in.                                                                                                               |
+| `signIn()`                | Silent / restore previous sign-in. With `offlineAccess: true`, iOS silent restore does not return `serverAuthCode` — use `createAccount()` for the initial offline grant. |
 | `createAccount()`         | Interactive account picker (sign-up).                                                                                                            |
-| `presentExplicitSignIn()` | Explicit Sign in with Google UI.                                                                                                                 |
+| `presentExplicitSignIn()` | Explicit Sign in with Google UI. On Android, when `hostedDomain` is set, JWT `hd` is validated after sign-in (Credential Manager flows filter at request time). |
 | `requestScopes(scopes)`   | Request **additional** OAuth access after sign-in; returns `{ serverAuthCode }`. Requires `offlineAccess: true` in `configure()` for a non-null code. |
 | `getTokens()`             | Returns `{ idToken, accessToken }` for the signed-in user. Throws `SIGN_IN_REQUIRED` if not signed in. |
 | `clearCachedAccessToken(token)` | Clears stale access token cache (Android) or marks session for refresh (iOS). Call before `getTokens()` after a 401. |
 | `signOut()`               | Clears local Google session (iOS SDK); disable auto sign-in on Android.                                                                          |
-| `revokeAccess(id)`        | Disconnect app (revokes app access / OAuth grant on both iOS and Android).                                                                       |
+| `revokeAccess(id)`        | Disconnect app (revokes OAuth grant). Android resolves account by email/id; iOS only revokes the current session (throws if `id` does not match). |
 
 
 Also exported: native [`GoogleSignInButton`](https://react-native-nitro-google-sign-in.github.io/docs/guide/google-sign-in-button), `useGoogleSignInFromButton`, response helpers (`isSuccessResponse`, `isNoSavedCredentialFoundResponse`, `isCancelledResponse`, `isErrorWithCode`), and `statusCodes`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,3 +41,42 @@ We aim to acknowledge reports within **5 business days** and will work with you 
 We appreciate responsible disclosure. Credit will be given in the advisory or release notes when you agree.
 
 **Docs:** [Security policy on the documentation site](https://react-native-nitro-google-sign-in.github.io/docs/community/security)
+
+## Backend verification checklist (consumer apps)
+
+This library returns Google-issued `idToken` and `serverAuthCode` values to your JavaScript layer. **Your backend is the trust anchor** — never accept tokens from the client without verification.
+
+### ID token (`idToken`)
+
+On every sign-in, verify the JWT on your server:
+
+1. Fetch Google JWKS from `https://www.googleapis.com/oauth2/v3/certs` (cache keys; respect `Cache-Control`).
+2. Verify the **RS256** signature against the matching key (`kid` header).
+3. Validate **`aud`** equals your **Web OAuth client ID** (`*.apps.googleusercontent.com`).
+4. Validate **`iss`** is `accounts.google.com` or `https://accounts.google.com`.
+5. Reject expired tokens (`exp` in the past).
+6. If you use **`configure({ nonce })`**, verify the JWT **`nonce`** claim matches the server-issued value stored in the user session.
+7. If you use **`hostedDomain`**, validate the JWT **`hd`** claim equals your Workspace domain — **do not rely on client-side filtering alone** (Android `buttonFlow` validates `hd` post sign-in; other paths may filter at request time).
+8. If you authorize by email, optionally require **`email_verified: true`**.
+
+Reject forged or tampered tokens (e.g. modify the payload in [jwt.io](https://jwt.io) and confirm your backend rejects it).
+
+### Server auth code (`serverAuthCode`)
+
+- Requires `configure({ offlineAccess: true })`.
+- Exchange the code **only on your backend** using your OAuth client secret.
+- Treat codes as **single-use and short-lived**; never log full codes in analytics or crash reporters.
+- On iOS, silent `signIn()` does not return a `serverAuthCode` even when `offlineAccess` is enabled — use `createAccount()` or `presentExplicitSignIn()` for the initial offline grant.
+
+### Token storage on device
+
+- Do not store `idToken` in plain AsyncStorage; prefer secure storage or session cookies managed by your app.
+- Implement logout, token rotation, and revocation (`signOut`, `revokeAccess`) in your auth flow.
+
+### Platform notes
+
+| Topic | Android | iOS |
+|-------|---------|-----|
+| `hostedDomain` | Credential Manager flows filter at request time; `buttonFlow` / `presentExplicitSignIn` validates JWT `hd` after sign-in | Applied via `GIDConfiguration.hostedDomain` |
+| `revokeAccess(id)` | Resolves account by email or user id | Only revokes the **current** session; throws if `id` does not match |
+| `signIn()` + `offlineAccess` | May follow with authorization for `serverAuthCode` | Silent restore returns `serverAuthCode: null` |

--- a/android/src/main/java/com/nitrogooglesignin/GoogleSignInAuthorizationHelper.kt
+++ b/android/src/main/java/com/nitrogooglesignin/GoogleSignInAuthorizationHelper.kt
@@ -9,6 +9,8 @@ import com.google.android.gms.auth.api.identity.Identity
 import com.google.android.gms.common.api.Scope
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -30,6 +32,7 @@ internal object GoogleSignInAuthorizationHelper : ActivityEventListener {
     )
   private var listenerRegistered = false
   private var pendingContinuation: CancellableContinuation<AuthorizationResultData>? = null
+  private val authorizeMutex = Mutex()
 
   fun ensureRegistered(context: ReactApplicationContext) {
     if (!listenerRegistered) {
@@ -52,68 +55,70 @@ internal object GoogleSignInAuthorizationHelper : ActivityEventListener {
 
     ensureRegistered(context)
 
-    return suspendCancellableCoroutine { continuation ->
-      pendingContinuation = continuation
-      continuation.invokeOnCancellation { pendingContinuation = null }
+    return authorizeMutex.withLock {
+      suspendCancellableCoroutine { continuation ->
+        pendingContinuation = continuation
+        continuation.invokeOnCancellation { pendingContinuation = null }
 
-      val requestBuilder =
-        AuthorizationRequest.builder()
-          .setRequestedScopes(resolvedScopes.map { Scope(it) })
-      if (offlineAccess) {
-        requestBuilder.requestOfflineAccess(serverClientId)
-        requestBuilder.setPrompt(AuthorizationRequest.Prompt.CONSENT)
-      }
+        val requestBuilder =
+          AuthorizationRequest.builder()
+            .setRequestedScopes(resolvedScopes.map { Scope(it) })
+        if (offlineAccess) {
+          requestBuilder.requestOfflineAccess(serverClientId)
+          requestBuilder.setPrompt(AuthorizationRequest.Prompt.CONSENT)
+        }
 
-      Identity.getAuthorizationClient(activity)
-        .authorize(requestBuilder.build())
-        .addOnSuccessListener { authorizationResult ->
-          if (authorizationResult.hasResolution()) {
-            val pendingIntent =
-              authorizationResult.pendingIntent
-                ?: run {
-                  clearPending(continuation)
-                  continuation.resumeWithException(
-                    GoogleSignInException(
-                      code = "ONE_TAP_START_FAILED",
-                      message = "Authorization required but no pending intent was returned.",
-                    ),
-                  )
-                  return@addOnSuccessListener
-                }
-            try {
-              @Suppress("DEPRECATION")
-              activity.startIntentSenderForResult(
-                pendingIntent.intentSender,
-                AUTH_REQUEST_CODE,
-                null,
-                0,
-                0,
-                0,
-                null,
-              )
-            } catch (e: Exception) {
+        Identity.getAuthorizationClient(activity)
+          .authorize(requestBuilder.build())
+          .addOnSuccessListener { authorizationResult ->
+            if (authorizationResult.hasResolution()) {
+              val pendingIntent =
+                authorizationResult.pendingIntent
+                  ?: run {
+                    clearPending(continuation)
+                    continuation.resumeWithException(
+                      GoogleSignInException(
+                        code = "ONE_TAP_START_FAILED",
+                        message = "Authorization required but no pending intent was returned.",
+                      ),
+                    )
+                    return@addOnSuccessListener
+                  }
+              try {
+                @Suppress("DEPRECATION")
+                activity.startIntentSenderForResult(
+                  pendingIntent.intentSender,
+                  AUTH_REQUEST_CODE,
+                  null,
+                  0,
+                  0,
+                  0,
+                  null,
+                )
+              } catch (e: Exception) {
+                clearPending(continuation)
+                continuation.resumeWithException(
+                  GoogleSignInException(
+                    code = "ONE_TAP_START_FAILED",
+                    message = e.message ?: "Failed to start authorization UI.",
+                  ),
+                )
+              }
+            } else {
               clearPending(continuation)
-              continuation.resumeWithException(
-                GoogleSignInException(
-                  code = "ONE_TAP_START_FAILED",
-                  message = e.message ?: "Failed to start authorization UI.",
-                ),
-              )
+              continuation.resume(authorizationResult.toData())
             }
-          } else {
-            clearPending(continuation)
-            continuation.resume(authorizationResult.toData())
           }
-        }
-        .addOnFailureListener { error ->
-          clearPending(continuation)
-          continuation.resumeWithException(
-            GoogleSignInException(
-              code = "ONE_TAP_START_FAILED",
-              message = error.message ?: "Authorization failed.",
-            ),
-          )
-        }
+          .addOnFailureListener { error ->
+            clearPending(continuation)
+            continuation.resumeWithException(
+              GoogleSignInException(
+                code = "ONE_TAP_START_FAILED",
+                message = error.message ?: "Authorization failed.",
+              ),
+            )
+          }
+      }
     }
   }
 

--- a/android/src/main/java/com/nitrogooglesignin/GoogleSignInController.kt
+++ b/android/src/main/java/com/nitrogooglesignin/GoogleSignInController.kt
@@ -40,12 +40,14 @@ import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
 import android.util.Base64
+import android.util.Log
 import com.google.android.gms.auth.api.identity.ClearTokenRequest
 import com.google.android.gms.auth.api.identity.Identity
 import com.google.android.gms.auth.api.identity.RevokeAccessRequest
 import com.google.android.gms.common.api.Scope
 
 internal object GoogleSignInController {
+  private const val TAG = "GoogleSignInController"
   private var webClientId: String? = null
   private var offlineAccess: Boolean = false
   private var hostedDomain: String? = null
@@ -350,6 +352,7 @@ internal object GoogleSignInController {
 
     val googleCredential = GoogleIdTokenCredential.createFrom(credential.data)
     val claims = IdTokenClaims.parse(googleCredential.idToken)
+    validateHostedDomain(claims)
     val deprecatedId = googleCredential.id
     // Deprecated `id` is often the email; `uniqueId` is the stable Google account id (JWT `sub`).
     val userId =
@@ -402,6 +405,19 @@ internal object GoogleSignInController {
     return OneTapResponse.success(
       data.copy(serverAuthCode = authResult.serverAuthCode.toOptionalStringVariant()),
     )
+  }
+
+  private fun validateHostedDomain(claims: IdTokenClaims?) {
+    val requiredDomain = hostedDomain ?: return
+    val tokenDomain = claims?.hd
+    if (tokenDomain == null || !tokenDomain.equals(requiredDomain, ignoreCase = true)) {
+      throw GoogleSignInException(
+        code = "ONE_TAP_START_FAILED",
+        message =
+          "Signed-in account is not in the required Google Workspace domain ($requiredDomain). " +
+            "Validate the JWT hd claim on your backend.",
+      )
+    }
   }
 
   private fun resolveWebClientId(context: Context, configuredId: String): String {
@@ -563,7 +579,7 @@ internal object GoogleSignInController {
         .putString(hashedLastSignedIn, encryptedUniqueId)
         .apply()
     } catch (e: Exception) {
-      // Log or silently ignore to not crash sign-in on prefs failure
+      Log.w(TAG, "Failed to save email mapping to encrypted storage", e)
     }
   }
 
@@ -606,7 +622,9 @@ internal object GoogleSignInController {
       val encryptedIdToken = SecureStorageHelper.encrypt(idToken) ?: return
       val hashedIdTokenKey = SecureStorageHelper.hashKey("${uniqueId}_id_token")
       prefs.edit().putString(hashedIdTokenKey, encryptedIdToken).apply()
-    } catch (e: Exception) {}
+    } catch (e: Exception) {
+      Log.w(TAG, "Failed to save ID token to encrypted storage", e)
+    }
   }
 
   private fun getIdTokenFromStorage(context: Context, uniqueId: String): String? {
@@ -627,7 +645,9 @@ internal object GoogleSignInController {
       val encryptedScopes = SecureStorageHelper.encrypt(scopesString) ?: return
       val hashedScopesKey = SecureStorageHelper.hashKey("${uniqueId}_scopes")
       prefs.edit().putString(hashedScopesKey, encryptedScopes).apply()
-    } catch (e: Exception) {}
+    } catch (e: Exception) {
+      Log.w(TAG, "Failed to save scopes to encrypted storage", e)
+    }
   }
 
   private fun getScopesFromStorage(context: Context, uniqueId: String): Set<String> {
@@ -654,7 +674,9 @@ internal object GoogleSignInController {
         .remove(SecureStorageHelper.hashKey("last_signed_in_user_id"))
         .remove(SecureStorageHelper.hashKey("${lastUserId}_id_token"))
         .apply()
-    } catch (e: Exception) {}
+    } catch (e: Exception) {
+      Log.w(TAG, "Failed to clear signed-in session from encrypted storage", e)
+    }
   }
 
   private fun removeUserDataFromStorage(context: Context, emailOrUniqueId: String) {
@@ -678,7 +700,7 @@ internal object GoogleSignInController {
       editor.remove(SecureStorageHelper.hashKey("last_signed_in_user_id"))
       editor.apply()
     } catch (e: Exception) {
-      // Silently ignore
+      Log.w(TAG, "Failed to remove user data from encrypted storage", e)
     }
   }
 

--- a/android/src/main/java/com/nitrogooglesignin/IdTokenClaims.kt
+++ b/android/src/main/java/com/nitrogooglesignin/IdTokenClaims.kt
@@ -6,6 +6,8 @@ import org.json.JSONObject
 internal data class IdTokenClaims(
   val sub: String?,
   val email: String?,
+  /** Google Workspace hosted domain (`hd` claim). Present only for Workspace accounts. */
+  val hd: String?,
 ) {
   companion object {
     fun parse(idToken: String): IdTokenClaims? =
@@ -20,6 +22,7 @@ internal data class IdTokenClaims(
         IdTokenClaims(
           sub = json.optString("sub").takeIf { it.isNotEmpty() },
           email = json.optString("email").takeIf { it.isNotEmpty() },
+          hd = json.optString("hd").takeIf { it.isNotEmpty() },
         )
       } catch (_: Exception) {
         null

--- a/example-expo/App.tsx
+++ b/example-expo/App.tsx
@@ -58,11 +58,9 @@ export default function App() {
   useEffect(() => {
     GoogleOneTapSignIn.configure({
       webClientId: WEB_CLIENT_ID,
+      offlineAccess: false,
     })
   }, [])
-
-  console.log('tokensStatus', tokensStatus)
-  console.log('lastAccessToken', lastAccessToken)
 
   const onSignInSuccess = (data: OneTapSuccessData) => {
     setUser(data)

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -62,9 +62,6 @@ function App(): React.JSX.Element {
     });
   }, []);
 
-  console.log('lastAccessToken', lastAccessToken);
-  console.log('tokensStatus', tokensStatus);
-
   const onSignInSuccess = (data: OneTapSuccessData) => {
     setUser(data);
     setTokensStatus(null);

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -62,7 +62,7 @@ PODS:
   - hermes-engine (250829098.0.14):
     - hermes-engine/Pre-built (= 250829098.0.14)
   - hermes-engine/Pre-built (250829098.0.14)
-  - NitroGoogleSignin (0.8.2):
+  - NitroGoogleSignin (1.0.1):
     - GoogleSignIn (< 9.2.0, ~> 9.0)
     - hermes-engine
     - NitroModules
@@ -2293,7 +2293,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 77880c98268570c547adcad251253b3187c9457b
-  NitroGoogleSignin: f547dfdf3bac83bd66c7830c3cc342cc68d4a2b4
+  NitroGoogleSignin: 4a3655c87b32141b59060d410784510c7d4c5fac
   NitroModules: 16bc17a076b12304d608f7c915b9d321f56dfc19
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b

--- a/ios/HybridNitroGoogleSignin.swift
+++ b/ios/HybridNitroGoogleSignin.swift
@@ -120,6 +120,24 @@ class HybridNitroGoogleSignin: HybridNitroGoogleSigninSpec {
 
   func revokeAccess(emailOrUniqueId: String) throws -> Promise<Void> {
     return Promise.async {
+      try await MainActor.run {
+        guard let currentUser = GIDSignIn.sharedInstance.currentUser else {
+          throw GoogleSignInNativeError.signInRequired(
+            "No signed-in Google user. Sign in before calling revokeAccess()."
+          )
+        }
+        let userId = currentUser.userID ?? ""
+        let email = currentUser.profile?.email ?? ""
+        let matches =
+          emailOrUniqueId == userId
+          || (!email.isEmpty && emailOrUniqueId == email)
+        guard matches else {
+          throw GoogleSignInNativeError.oneTapStartFailed(
+            "emailOrUniqueId does not match the current signed-in user on iOS. " +
+              "Only the active session can be revoked; call signIn() first or use signOut()."
+          )
+        }
+      }
       try await withCheckedThrowingContinuation {
         (continuation: CheckedContinuation<Void, Error>) in
         DispatchQueue.main.async {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-google-signin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Google Sign-In and One Tap for React Native and Expo — OAuth 2.0 / OpenID Connect with Android Credential Manager and Google Sign-In SDK (iOS). Powered by Nitro Modules.",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index.js",

--- a/skills/react-native-nitro-google-signin/SKILL.md
+++ b/skills/react-native-nitro-google-signin/SKILL.md
@@ -34,6 +34,9 @@ Requires RN ≥ 0.76. **Not Expo Go** — use `expo-dev-client`.
 | API | `GoogleOneTapSignIn` from `react-native-nitro-google-signin` |
 | Configure first | `GoogleOneTapSignIn.configure({ webClientId })` before sign-in |
 | `serverAuthCode` | Requires `offlineAccess: true` in `configure()` — otherwise always `null` |
+| Backend | Verify every `idToken` on server (sig, `aud`, `iss`, `exp`); validate JWT `hd` if using `hostedDomain` |
+| iOS offline grant | Silent `signIn()` returns `serverAuthCode: null` — use `createAccount()` for initial code |
+| `revokeAccess` | Android: by email/id. iOS: current session only (throws if id mismatch) |
 | `getTokens` | After sign-in; throws `SIGN_IN_REQUIRED` if no session. iOS: call `clearCachedAccessToken` before retry after 401 |
 | Flow order | `checkPlayServices` → `signIn` → `createAccount` → `presentExplicitSignIn` |
 | Android `autoDetect` | Needs `google-services.json` + `com.google.gms.google-services` plugin |

--- a/skills/react-native-nitro-google-signin/examples.md
+++ b/skills/react-native-nitro-google-signin/examples.md
@@ -35,6 +35,8 @@ await GoogleOneTapSignIn.requestScopes([
 ])
 ```
 
+On **iOS**, use `createAccount()` or `presentExplicitSignIn()` (not silent `signIn()`) for the initial offline grant that returns a `serverAuthCode`.
+
 ## Access tokens (legacy migration)
 
 After sign-in, fetch OAuth tokens without re-running the account picker:

--- a/skills/react-native-nitro-google-signin/reference.md
+++ b/skills/react-native-nitro-google-signin/reference.md
@@ -21,7 +21,14 @@ Full types: https://react-native-nitro-google-sign-in.github.io/docs/guide/api-r
 | `getTokens()`                      | `{ idToken, accessToken }` after sign-in; throws `SIGN_IN_REQUIRED` if not signed in |
 | `clearCachedAccessToken(token)`    | Clears cached access token (Android) or marks session for refresh (iOS) |
 | `signOut()`                      | iOS GIDSignOut; Android disables auto sign-in semantics                                              |
-| `revokeAccess(id)`               | Revokes app access / OAuth grant (iOS and Android)                                                   |
+| `revokeAccess(id)`               | Android: revokes by email/id. iOS: current session only — throws if `id` does not match active user |
+
+### Platform security notes
+
+- **Backend:** Always verify `idToken` on your server (signature, `aud`, `iss`, `exp`). See repo `SECURITY.md`.
+- **`hostedDomain`:** Validate JWT `hd` on backend. Android `buttonFlow` / `presentExplicitSignIn` validates `hd` after sign-in; Credential Manager flows filter at request time. iOS uses `GIDConfiguration.hostedDomain`.
+- **`offlineAccess` + `signIn()`:** iOS silent restore returns `serverAuthCode: null` — use `createAccount()` for initial offline grant.
+- **`serverAuthCode`:** Never log full codes in UI, analytics, or crash reporters.
 
 ### Types
 

--- a/src/GoogleOneTapSignIn.ts
+++ b/src/GoogleOneTapSignIn.ts
@@ -44,6 +44,11 @@ export const GoogleOneTapSignIn = {
    * Android: Credential Manager with authorized accounts only.
    * iOS: current user or `restorePreviousSignIn()`.
    *
+   * When `configure({ offlineAccess: true })`, **`serverAuthCode` is `null` on
+   * this silent path on iOS** (and on Android until authorization completes).
+   * Use {@link createAccount} or {@link presentExplicitSignIn} for the initial
+   * offline-access grant that returns a `serverAuthCode`.
+   *
    * User cancel is returned as `type: 'cancelled'`, not thrown.
    */
   signIn(): Promise<OneTapResponse> {
@@ -63,7 +68,9 @@ export const GoogleOneTapSignIn = {
   /**
    * Explicit **Sign in with Google** UI.
    *
-   * Android: `GetSignInWithGoogleOption` account dialog.
+   * Android: `GetSignInWithGoogleOption` account dialog. When `hostedDomain` is
+   * configured, the JWT `hd` claim is validated after sign-in (Credential Manager
+   * flows apply the filter during the request).
    * iOS: same interactive flow as {@link createAccount}.
    */
   presentExplicitSignIn(): Promise<OneTapResponse> {
@@ -114,6 +121,13 @@ export const GoogleOneTapSignIn = {
 
   /**
    * Revoke app access / OAuth grant for the user.
+   *
+   * **Android:** resolves the account from `emailOrUniqueId` (email or
+   * `OneTapUser.id`).
+   *
+   * **iOS:** only revokes the **current signed-in session**; throws if
+   * `emailOrUniqueId` does not match the active user. Call {@link signIn} first
+   * when revoking a specific stored account.
    *
    * @param emailOrUniqueId User email or stable Google account id (`OneTapUser.id`).
    */

--- a/src/specs/nitro-google-signin.nitro.ts
+++ b/src/specs/nitro-google-signin.nitro.ts
@@ -64,7 +64,18 @@ export interface OneTapConfigureParams {
    * is always `null`.
    */
   offlineAccess?: boolean
-  /** Restrict sign-in to a Google Workspace domain (e.g. `example.com`). */
+  /** Restrict sign-in to a Google Workspace domain (e.g. `example.com`).
+   *
+   * Android Credential Manager flows (`signIn`, `createAccount`) pass this to
+   * `GetGoogleIdOption.setHostedDomainFilter`. The explicit button flow
+   * (`presentExplicitSignIn`, `GoogleSignInButton` with `signInBehavior="buttonFlow"`)
+   * validates the JWT `hd` claim after sign-in instead.
+   *
+   * iOS: passed to `GIDConfiguration.hostedDomain`.
+   *
+   * **Always validate the JWT `hd` claim on your backend** — do not rely on
+   * client-side filtering alone.
+   */
   hostedDomain?: string | null
   /** SHA-256 hex nonce for the ID token. Auto-generated when omitted. */
   nonce?: string | null
@@ -124,5 +135,16 @@ export interface NitroGoogleSignin
    */
   clearCachedAccessToken(accessTokenString: string): Promise<void>
   signOut(): Promise<void>
+  /**
+   * Revoke app access / OAuth grant for the user.
+   *
+   * **Android:** resolves the account from `emailOrUniqueId` (email or
+   * {@link OneTapUser.id}) and revokes via `AuthorizationClient`.
+   *
+   * **iOS:** only the **current signed-in session** can be revoked. Throws if
+   * `emailOrUniqueId` does not match the active user's id or email. The
+   * parameter is ignored for account lookup — call {@link signIn} first if you
+   * need to revoke a specific stored account.
+   */
   revokeAccess(emailOrUniqueId: string): Promise<void>
 }


### PR DESCRIPTION
## Summary
- Hardens Android: `hostedDomain` JWT `hd` validation on button flow, `authorize()` mutex, encrypted storage failure logging
- Aligns iOS `revokeAccess` with current-session semantics
- Adds backend verification checklist to `SECURITY.md` and updates API/docs/skills/examples

## Test plan
- [ ] `bun run build` passes
- [ ] `./gradlew :react-native-nitro-google-signin:compileDebugKotlin` passes
- [ ] Sign-in flows still return `serverAuthCode` when `offlineAccess: true`
- [ ] Android `hostedDomain` rejects non-Workspace accounts on button flow
- [ ] iOS `revokeAccess` throws when id does not match current user