### PR TITLE
fix(android): clarify cancelled after account pick on production

### DIFF
--- a/android/src/main/java/com/nitrogooglesignin/GoogleSignInAuthorizationHelper.kt
+++ b/android/src/main/java/com/nitrogooglesignin/GoogleSignInAuthorizationHelper.kt
@@ -6,6 +6,8 @@ import com.facebook.react.bridge.ActivityEventListener
 import com.facebook.react.bridge.ReactApplicationContext
 import com.google.android.gms.auth.api.identity.AuthorizationRequest
 import com.google.android.gms.auth.api.identity.Identity
+import com.google.android.gms.common.api.ApiException
+import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.common.api.Scope
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -111,12 +113,7 @@ internal object GoogleSignInAuthorizationHelper : ActivityEventListener {
           }
           .addOnFailureListener { error ->
             clearPending(continuation)
-            continuation.resumeWithException(
-              GoogleSignInException(
-                code = "ONE_TAP_START_FAILED",
-                message = error.message ?: "Authorization failed.",
-              ),
-            )
+            continuation.resumeWithException(mapAuthorizationFailure(error))
           }
       }
     }
@@ -134,12 +131,25 @@ internal object GoogleSignInAuthorizationHelper : ActivityEventListener {
     clearPending(continuation)
 
     if (resultCode != Activity.RESULT_OK || data == null) {
-      continuation.resumeWithException(
-        GoogleSignInException(
-          code = "SIGN_IN_CANCELLED",
-          message = "Flow cancelled or failed with resultCode: $resultCode"
+      // RESULT_CANCELED is user dismiss OR OAuth misconfiguration (same conflation as
+      // Credential Manager). Other non-OK codes are real failures, not user cancel.
+      if (resultCode == Activity.RESULT_CANCELED) {
+        continuation.resumeWithException(
+          GoogleSignInException(
+            code = "SIGN_IN_CANCELLED",
+            message =
+              "Authorization UI cancelled. If this happens on production builds after " +
+                "account selection, verify release and Play App Signing SHA-1 on the Android OAuth client.",
+          ),
         )
-      )
+      } else {
+        continuation.resumeWithException(
+          GoogleSignInException(
+            code = "ONE_TAP_START_FAILED",
+            message = "Authorization failed with resultCode: $resultCode",
+          ),
+        )
+      }
       return
     }
 
@@ -162,6 +172,30 @@ internal object GoogleSignInAuthorizationHelper : ActivityEventListener {
   private fun clearPending(continuation: CancellableContinuation<AuthorizationResultData>? = null) {
     if (pendingContinuation === continuation || continuation == null) {
       pendingContinuation = null
+    }
+  }
+
+  private fun mapAuthorizationFailure(error: Exception): GoogleSignInException {
+    val apiException = error as? ApiException
+    val message = error.message ?: "Authorization failed."
+    return when (apiException?.statusCode) {
+      CommonStatusCodes.DEVELOPER_ERROR ->
+        GoogleSignInException(
+          code = "DEVELOPER_ERROR",
+          message =
+            "$message Check the Android OAuth client package name and SHA-1 fingerprints " +
+              "(debug, release upload key, and Play App Signing certificate).",
+        )
+      CommonStatusCodes.CANCELED ->
+        GoogleSignInException(
+          code = "SIGN_IN_CANCELLED",
+          message = message,
+        )
+      else ->
+        GoogleSignInException(
+          code = "ONE_TAP_START_FAILED",
+          message = message,
+        )
     }
   }
 

--- a/android/src/main/java/com/nitrogooglesignin/GoogleSignInController.kt
+++ b/android/src/main/java/com/nitrogooglesignin/GoogleSignInController.kt
@@ -8,6 +8,8 @@ import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.exceptions.GetCredentialCancellationException
 import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.GetCredentialInterruptedException
+import androidx.credentials.exceptions.GetCredentialProviderConfigurationException
 import androidx.credentials.exceptions.NoCredentialException
 import com.facebook.react.bridge.ReactApplicationContext
 import com.margelo.nitro.NitroModules
@@ -321,19 +323,67 @@ internal object GoogleSignInController {
         }
       enrichWithServerAuthCode(parseCredential(result.credential))
     } catch (e: GetCredentialCancellationException) {
+      // Credential Manager reports RESULT_CANCELED both for real user dismissals and for
+      // OAuth misconfiguration (missing/wrong SHA-1, package name, or Web vs Android client ID).
+      // Production-only "cancelled after picking an account" almost always means the Play App
+      // Signing / release SHA-1 is not registered on the Android OAuth client.
+      Log.w(
+        TAG,
+        "Credential Manager cancellation after getCredential. " +
+          "If the account picker appeared and this is a release/Play build, verify the Android " +
+          "OAuth client has the correct package name and SHA-1 (debug, release upload key, and " +
+          "Play Console App Signing certificate). Message: ${e.message}",
+      )
       OneTapResponse.cancelled()
     } catch (e: NoCredentialException) {
       OneTapResponse.noSavedCredential()
+    } catch (e: GetCredentialInterruptedException) {
+      throw GoogleSignInException(
+        code = "ONE_TAP_START_FAILED",
+        message = e.message ?: "Credential request was interrupted. Retry the sign-in.",
+      )
+    } catch (e: GetCredentialProviderConfigurationException) {
+      throw GoogleSignInException(
+        code = "ONE_TAP_START_FAILED",
+        message =
+          e.message
+            ?: "Credential provider is not configured. Ensure credentials-play-services-auth is linked.",
+      )
     } catch (e: GetCredentialException) {
       if (e.message?.contains("no credentials", ignoreCase = true) == true) {
         OneTapResponse.noSavedCredential()
       } else {
-        throw GoogleSignInException(
-          code = "ONE_TAP_START_FAILED",
-          message = e.message ?: "Credential request failed.",
-        )
+        throw mapGetCredentialFailure(e)
       }
     }
+  }
+
+  private fun mapGetCredentialFailure(e: GetCredentialException): GoogleSignInException {
+    val message = e.message?.takeIf { it.isNotBlank() } ?: "Credential request failed."
+    if (looksLikeDeveloperError(message)) {
+      return GoogleSignInException(
+        code = "DEVELOPER_ERROR",
+        message =
+          "$message Check the Android OAuth client package name and SHA-1 fingerprints " +
+            "(debug, release upload key, and Play App Signing certificate). " +
+            "Use the Web client ID in configure({ webClientId }), not the Android client ID.",
+      )
+    }
+    return GoogleSignInException(
+      code = "ONE_TAP_START_FAILED",
+      message = message,
+    )
+  }
+
+  private fun looksLikeDeveloperError(message: String): Boolean {
+    val normalized = message.lowercase()
+    return normalized.contains("developer") ||
+      normalized.contains("console is not set up") ||
+      // CommonStatusCodes.DEVELOPER_ERROR == 10
+      normalized.contains("10:") ||
+      normalized.contains("[10]") ||
+      normalized.contains("sha-1") ||
+      normalized.contains("sha1")
   }
 
   private fun parseCredential(credential: androidx.credentials.Credential): OneTapSuccessData {

--- a/skills/react-native-nitro-google-signin/SKILL.md
+++ b/skills/react-native-nitro-google-signin/SKILL.md
@@ -79,11 +79,12 @@ if (isSuccessResponse(response)) {
 | Symptom | Likely fix |
 | ------- | ---------- |
 | `DEVELOPER_ERROR` (Android) | Wrong SHA-1 or package on OAuth client |
+| `type: 'cancelled'` after picking account (Android release/Play) | Missing **Play App Signing** / release SHA-1 on Android OAuth client — [troubleshooting](https://react-native-nitro-google-sign-in.github.io/docs/guide/troubleshooting#cancelled-after-account-pick) |
 | `default_web_client_id was not found` | Add `google-services.json` + Gradle plugin |
 | iOS redirect fails | Fix `REVERSED_CLIENT_ID` URL scheme |
 | `pod install` / Expo prebuild — AppCheckCore modular headers | Expo: `prebuild --clean` (plugin patches Podfile). Bare: add AppCheckCore/GoogleUtilities/RecaptchaInterop pods to `ios/Podfile` — [troubleshooting](https://react-native-nitro-google-sign-in.github.io/docs/guide/troubleshooting#ios-pod-install-fails--appcheckcore--recaptchainterop-expo-56) |
 | Nitro not found | Rebuild dev client / `bundle exec pod install --project-directory="ios"` |
-| Sign-in OK in debug, fails in release | Consumer ProGuard rules ship with library; avoid `-keep androidx.**`; test `assembleRelease` |
+| Sign-in OK in debug, fails in release | Consumer ProGuard rules ship with library; avoid `-keep androidx.**`; test `assembleRelease`. Also check release/Play SHA-1 (see cancelled-after-account-pick above) |
 
 ## More detail
 

--- a/skills/react-native-nitro-google-signin/reference.md
+++ b/skills/react-native-nitro-google-signin/reference.md
@@ -82,7 +82,7 @@ Use explicit `webClientId` on Android (no `google-services.json`).
 
 **Credential Manager + GMS:** Library ships `androidx.credentials`, `credentials-play-services-auth`, `googleid`, `play-services-auth` — do not add duplicates unless you use Credential Manager for other providers. Play services on device required; call `checkPlayServices()`. Use **Web** client ID in `configure()`, not Android client ID.
 
-**OAuth:** Android client with package name + SHA-1 (debug & release).
+**OAuth:** Android client with package name + SHA-1 (debug & release **and Play App Signing** for store builds). Missing Play signing SHA-1 often surfaces as `type: 'cancelled'` after account pick, not `DEVELOPER_ERROR`.
 
 **Omit `google-services.json` + Gradle plugin** when using explicit `webClientId` (SHA-1 still required).
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,13 @@ export const statusCodes = {
   SIGN_IN_REQUIRED: 'SIGN_IN_REQUIRED',
   /** User cancelled an authorization or sign-in flow. */
   SIGN_IN_CANCELLED: 'SIGN_IN_CANCELLED',
+  /**
+   * Android OAuth misconfiguration (wrong/missing SHA-1, package name, or
+   * Android client ID used as `webClientId`). Thrown when Credential Manager /
+   * AuthorizationClient surfaces a developer error — not for silent `cancelled`
+   * responses (see troubleshooting for production `cancelled` after account pick).
+   */
+  DEVELOPER_ERROR: 'DEVELOPER_ERROR',
 } as const
 
 export type StatusCode = (typeof statusCodes)[keyof typeof statusCodes]


### PR DESCRIPTION
## Summary

- **Root cause (issue #42):** On Android production/Play builds, a missing **Play App Signing** (or release) SHA-1 on the Android OAuth client causes Credential Manager to finish with `RESULT_CANCELED` after the user picks an account. androidx.credentials maps that to `GetCredentialCancellationException` ("activity is cancelled by the user"), and this library returns `type: 'cancelled'`. That is Google’s conflation of real cancel and OAuth misconfiguration — not a silent swallow of `DEVELOPER_ERROR` on the common path.
- **Library improvements:** Log a clear SHA-1 warning on cancellation; map known developer-error messages to `statusCodes.DEVELOPER_ERROR`; distinguish authorization `RESULT_CANCELED` vs other result codes; update agent skill + docs.

Fixes #42

Docs PR: https://github.com/react-native-nitro-google-sign-in/react-native-nitro-google-sign-in.github.io/pull/3

## Test plan

- [x] `bun run build` / `bun run typecheck`
- [x] `cd docs && bun run build`
- [ ] Reproduce on release/Play build with only debug SHA-1 registered → expect `cancelled` + logcat warning from `GoogleSignInController`
- [ ] Add Play App Signing SHA-1 to Android OAuth client → expect `success` after account pick
- [ ] Confirm real user dismiss of the picker still returns `type: 'cancelled'`
- [ ] When Credential Manager returns an explicit developer-error message, expect thrown `DEVELOPER_ERROR`

## Docs

- [x] Updated docs submodule + agent skill