### PR TITLE
fix: Android offlineAccess hang and requestScopes consent

### DIFF
--- a/android/src/main/java/com/nitrogooglesignin/GoogleSignInAuthorizationHelper.kt
+++ b/android/src/main/java/com/nitrogooglesignin/GoogleSignInAuthorizationHelper.kt
@@ -1,5 +1,6 @@
 package com.nitrogooglesignin
 
+import android.accounts.Account
 import android.app.Activity
 import android.content.Intent
 import com.facebook.react.bridge.ActivityEventListener
@@ -9,6 +10,7 @@ import com.google.android.gms.auth.api.identity.Identity
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.common.api.Scope
+import com.google.android.gms.tasks.Task
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
@@ -33,7 +35,8 @@ internal object GoogleSignInAuthorizationHelper : ActivityEventListener {
       "profile",
     )
   private var listenerRegistered = false
-  private var pendingContinuation: CancellableContinuation<AuthorizationResultData>? = null
+  private var pendingContinuation: CancellableContinuation<com.google.android.gms.auth.api.identity.AuthorizationResult>? =
+    null
   private val authorizeMutex = Mutex()
 
   fun ensureRegistered(context: ReactApplicationContext) {
@@ -49,6 +52,7 @@ internal object GoogleSignInAuthorizationHelper : ActivityEventListener {
     serverClientId: String,
     scopes: List<String>,
     offlineAccess: Boolean,
+    accountEmail: String? = null,
   ): AuthorizationResultData {
     val resolvedScopes =
       scopes.filter { it.isNotBlank() }.ifEmpty {
@@ -58,66 +62,108 @@ internal object GoogleSignInAuthorizationHelper : ActivityEventListener {
     ensureRegistered(context)
 
     return authorizeMutex.withLock {
-      suspendCancellableCoroutine { continuation ->
-        pendingContinuation = continuation
-        continuation.invokeOnCancellation { pendingContinuation = null }
+      val requestBuilder =
+        AuthorizationRequest.builder()
+          .setRequestedScopes(resolvedScopes.map { Scope(it) })
 
-        val requestBuilder =
-          AuthorizationRequest.builder()
-            .setRequestedScopes(resolvedScopes.map { Scope(it) })
-        if (offlineAccess) {
-          requestBuilder.requestOfflineAccess(serverClientId)
-          requestBuilder.setPrompt(AuthorizationRequest.Prompt.CONSENT)
+      // Bind to the signed-in account when known. Without this, AuthorizationClient
+      // may return an empty success (no resolution, no tokens) instead of showing consent.
+      accountEmail
+        ?.takeIf { it.contains("@") }
+        ?.let { email ->
+          requestBuilder.setAccount(Account(email, "com.google"))
         }
 
-        Identity.getAuthorizationClient(activity)
-          .authorize(requestBuilder.build())
-          .addOnSuccessListener { authorizationResult ->
-            if (authorizationResult.hasResolution()) {
-              val pendingIntent =
-                authorizationResult.pendingIntent
-                  ?: run {
-                    clearPending(continuation)
-                    continuation.resumeWithException(
-                      GoogleSignInException(
-                        code = "ONE_TAP_START_FAILED",
-                        message = "Authorization required but no pending intent was returned.",
-                      ),
-                    )
-                    return@addOnSuccessListener
-                  }
-              try {
-                @Suppress("DEPRECATION")
-                activity.startIntentSenderForResult(
-                  pendingIntent.intentSender,
-                  AUTH_REQUEST_CODE,
-                  null,
-                  0,
-                  0,
-                  0,
-                  null,
-                )
-              } catch (e: Exception) {
-                clearPending(continuation)
-                continuation.resumeWithException(
-                  GoogleSignInException(
-                    code = "ONE_TAP_START_FAILED",
-                    message = e.message ?: "Failed to start authorization UI.",
-                  ),
-                )
-              }
-            } else {
-              clearPending(continuation)
-              continuation.resume(authorizationResult.toData())
-            }
-          }
-          .addOnFailureListener { error ->
-            clearPending(continuation)
-            continuation.resumeWithException(mapAuthorizationFailure(error))
-          }
+      if (offlineAccess) {
+        // Request a server auth code. Do NOT force Prompt.CONSENT on every call —
+        // forcing consent after Credential Manager frequently hangs (PendingIntent
+        // never completes). Google still shows consent when offline access has not
+        // been granted yet. Use requestOfflineAccess(serverClientId) alone.
+        requestBuilder.requestOfflineAccess(serverClientId)
       }
+
+      val authClient = Identity.getAuthorizationClient(activity)
+      val initial =
+        try {
+          authClient.authorize(requestBuilder.build()).awaitTask()
+        } catch (error: Exception) {
+          throw mapAuthorizationFailure(error)
+        }
+
+      val resolved =
+        if (initial.hasResolution()) {
+          val pendingIntent =
+            initial.pendingIntent
+              ?: throw GoogleSignInException(
+                code = "ONE_TAP_START_FAILED",
+                message = "Authorization required but no pending intent was returned.",
+              )
+          awaitAuthorizationResolution(activity, pendingIntent.intentSender)
+        } else {
+          initial
+        }
+
+      val data = resolved.toData()
+      if (data.accessToken.isNullOrBlank() && data.serverAuthCode.isNullOrBlank()) {
+        throw GoogleSignInException(
+          code = "ONE_TAP_START_FAILED",
+          message =
+            "Authorization completed without an access token or server auth code. " +
+              "Ensure the user is signed in, the requested scopes are added on the OAuth " +
+              "consent screen, and try again.",
+        )
+      }
+      data
     }
   }
+
+  private suspend fun awaitAuthorizationResolution(
+    activity: Activity,
+    intentSender: android.content.IntentSender,
+  ): com.google.android.gms.auth.api.identity.AuthorizationResult =
+    suspendCancellableCoroutine { continuation ->
+      if (pendingContinuation != null) {
+        continuation.resumeWithException(
+          GoogleSignInException(
+            code = "IN_PROGRESS",
+            message = "Another authorization request is already in progress.",
+          ),
+        )
+        return@suspendCancellableCoroutine
+      }
+
+      pendingContinuation = continuation
+      continuation.invokeOnCancellation {
+        if (pendingContinuation === continuation) {
+          pendingContinuation = null
+        }
+      }
+
+      // startIntentSenderForResult must run on the main thread.
+      activity.runOnUiThread {
+        if (pendingContinuation !== continuation) return@runOnUiThread
+        try {
+          @Suppress("DEPRECATION")
+          activity.startIntentSenderForResult(
+            intentSender,
+            AUTH_REQUEST_CODE,
+            null,
+            0,
+            0,
+            0,
+            null,
+          )
+        } catch (e: Exception) {
+          clearPending(continuation)
+          continuation.resumeWithException(
+            GoogleSignInException(
+              code = "ONE_TAP_START_FAILED",
+              message = e.message ?: "Failed to start authorization UI.",
+            ),
+          )
+        }
+      }
+    }
 
   override fun onActivityResult(
     activity: Activity,
@@ -156,7 +202,7 @@ internal object GoogleSignInAuthorizationHelper : ActivityEventListener {
     try {
       val authorizationResult =
         Identity.getAuthorizationClient(activity).getAuthorizationResultFromIntent(data)
-      continuation.resume(authorizationResult.toData())
+      continuation.resume(authorizationResult)
     } catch (e: Exception) {
       continuation.resumeWithException(
         GoogleSignInException(
@@ -169,7 +215,10 @@ internal object GoogleSignInAuthorizationHelper : ActivityEventListener {
 
   override fun onNewIntent(intent: Intent) {}
 
-  private fun clearPending(continuation: CancellableContinuation<AuthorizationResultData>? = null) {
+  private fun clearPending(
+    continuation: CancellableContinuation<com.google.android.gms.auth.api.identity.AuthorizationResult>? =
+      null,
+  ) {
     if (pendingContinuation === continuation || continuation == null) {
       pendingContinuation = null
     }
@@ -205,4 +254,17 @@ internal object GoogleSignInAuthorizationHelper : ActivityEventListener {
       accessToken = accessToken,
       serverAuthCode = serverAuthCode,
     )
+
+  private suspend fun <T> Task<T>.awaitTask(): T =
+    suspendCancellableCoroutine { continuation ->
+      addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+          continuation.resume(task.result)
+        } else {
+          continuation.resumeWithException(
+            task.exception ?: RuntimeException("Authorization task failed."),
+          )
+        }
+      }
+    }
 }

--- a/android/src/main/java/com/nitrogooglesignin/GoogleSignInAuthorizationHelper.kt
+++ b/android/src/main/java/com/nitrogooglesignin/GoogleSignInAuthorizationHelper.kt
@@ -258,6 +258,9 @@ internal object GoogleSignInAuthorizationHelper : ActivityEventListener {
   private suspend fun <T> Task<T>.awaitTask(): T =
     suspendCancellableCoroutine { continuation ->
       addOnCompleteListener { task ->
+        // Avoid IllegalStateException if the parent coroutine was cancelled
+        // before the GMS Task completed.
+        if (!continuation.isActive) return@addOnCompleteListener
         if (task.isSuccessful) {
           continuation.resume(task.result)
         } else {

--- a/android/src/main/java/com/nitrogooglesignin/GoogleSignInController.kt
+++ b/android/src/main/java/com/nitrogooglesignin/GoogleSignInController.kt
@@ -202,24 +202,31 @@ internal object GoogleSignInController {
 
   suspend fun requestScopes(scopes: Array<String>): OneTapAuthorizationResult {
     requireConfigured()
+    val context = requireContext()
+    val lastUserId =
+      getLastSignedInUserId(context)
+        ?: throw GoogleSignInException(
+          code = "SIGN_IN_REQUIRED",
+          message = "No signed-in Google user. Sign in before requesting additional scopes.",
+        )
+    val accountEmail = getEmailFromStorage(context, lastUserId)
+
     val authResult =
       GoogleSignInAuthorizationHelper.authorize(
         activity = requireActivity(),
-        context = requireContext(),
+        context = context,
         serverClientId = webClientId!!,
         scopes = scopes.toList(),
         offlineAccess = offlineAccess,
+        accountEmail = accountEmail,
       )
 
-    val context = requireContext()
-    val lastUserId = getLastSignedInUserId(context)
-    if (lastUserId != null) {
-      val existingScopes = getScopesFromStorage(context, lastUserId)
-      val updatedScopes = existingScopes + scopes.toList()
-      saveScopesToStorage(context, lastUserId, updatedScopes)
-    }
+    val existingScopes = getScopesFromStorage(context, lastUserId)
+    val updatedScopes = existingScopes + scopes.toList()
+    saveScopesToStorage(context, lastUserId, updatedScopes)
 
     return OneTapAuthorizationResult(
+      accessToken = authResult.accessToken.toOptionalStringVariant(),
       serverAuthCode = authResult.serverAuthCode.toOptionalStringVariant(),
     )
   }
@@ -248,6 +255,7 @@ internal object GoogleSignInController {
         storedScopes.toList()
       }
 
+    val accountEmail = getEmailFromStorage(context, lastUserId)
     val authResult =
       GoogleSignInAuthorizationHelper.authorize(
         activity = requireActivity(),
@@ -255,6 +263,7 @@ internal object GoogleSignInController {
         serverClientId = webClientId!!,
         scopes = scopes,
         offlineAccess = false,
+        accountEmail = accountEmail,
       )
 
     val accessToken =
@@ -443,6 +452,7 @@ internal object GoogleSignInController {
       return OneTapResponse.success(data)
     }
 
+    val accountEmail = variantToString(data.user.email)
     val authResult =
       GoogleSignInAuthorizationHelper.authorize(
         activity = requireActivity(),
@@ -450,6 +460,7 @@ internal object GoogleSignInController {
         serverClientId = webClientId!!,
         scopes = configuredScopes,
         offlineAccess = offlineAccess,
+        accountEmail = accountEmail,
       )
 
     return OneTapResponse.success(

--- a/example-expo/App.tsx
+++ b/example-expo/App.tsx
@@ -105,13 +105,18 @@ export default function App() {
     setExtraScopesStatus('Requesting Drive full access…')
     try {
       const result = await GoogleOneTapSignIn.requestScopes([DRIVE_FULL_SCOPE])
-      if (result.serverAuthCode) {
+      if (result.accessToken) {
+        const authHint = result.serverAuthCode
+          ? `access token + server auth code (${result.serverAuthCode.slice(0, 12)}…)`
+          : 'access token (no server auth code — enable offlineAccess for that)'
+        setExtraScopesStatus(`Scope granted with ${authHint}.`)
+      } else if (result.serverAuthCode) {
         setExtraScopesStatus(
           `Scope granted. Server auth code received (${result.serverAuthCode.slice(0, 12)}…).`
         )
       } else {
         setExtraScopesStatus(
-          'Scope granted (or already granted). No new server auth code.'
+          'Authorization finished without an access token or server auth code.'
         )
       }
     } catch (e) {

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -106,13 +106,18 @@ function App(): React.JSX.Element {
     try {
       const result = await GoogleOneTapSignIn.requestScopes([DRIVE_FULL_SCOPE]);
 
-      if (result.serverAuthCode) {
+      if (result.accessToken) {
+        const authHint = result.serverAuthCode
+          ? `access token + server auth code (${result.serverAuthCode.slice(0, 12)}…)`
+          : 'access token (no server auth code — enable offlineAccess for that)';
+        setExtraScopesStatus(`Scope granted with ${authHint}.`);
+      } else if (result.serverAuthCode) {
         setExtraScopesStatus(
           `Scope granted. Server auth code received (${result.serverAuthCode.slice(0, 12)}…).`,
         );
       } else {
         setExtraScopesStatus(
-          'Scope granted (or already granted). No new server auth code.',
+          'Authorization finished without an access token or server auth code.',
         );
       }
     } catch (e) {

--- a/ios/HybridNitroGoogleSignin.swift
+++ b/ios/HybridNitroGoogleSignin.swift
@@ -502,13 +502,18 @@ class HybridNitroGoogleSignin: HybridNitroGoogleSigninSpec {
     if let error = error as NSError? {
       if error.code == GIDSignInError.canceled.rawValue {
         continuation.resume(
-          returning: OneTapAuthorizationResult(serverAuthCode: optionalStringVariant(nil))
+          returning: OneTapAuthorizationResult(
+            accessToken: optionalStringVariant(nil),
+            serverAuthCode: optionalStringVariant(nil)
+          )
         )
         return
       }
       if error.code == GIDSignInError.scopesAlreadyGranted.rawValue {
+        let user = result?.user ?? GIDSignIn.sharedInstance.currentUser
         continuation.resume(
           returning: OneTapAuthorizationResult(
+            accessToken: optionalStringVariant(user?.accessToken.tokenString),
             serverAuthCode: optionalStringVariant(result?.serverAuthCode)
           )
         )
@@ -521,6 +526,7 @@ class HybridNitroGoogleSignin: HybridNitroGoogleSigninSpec {
     }
     continuation.resume(
       returning: OneTapAuthorizationResult(
+        accessToken: optionalStringVariant(result?.user.accessToken.tokenString),
         serverAuthCode: optionalStringVariant(result?.serverAuthCode)
       )
     )

--- a/nitrogen/generated/android/c++/JOneTapAuthorizationResult.hpp
+++ b/nitrogen/generated/android/c++/JOneTapAuthorizationResult.hpp
@@ -36,9 +36,12 @@ namespace margelo::nitro::nitrogooglesignin {
     [[nodiscard]]
     OneTapAuthorizationResult toCpp() const {
       static const auto clazz = javaClassStatic();
+      static const auto fieldAccessToken = clazz->getField<JVariant_NullType_String>("accessToken");
+      jni::local_ref<JVariant_NullType_String> accessToken = this->getFieldValue(fieldAccessToken);
       static const auto fieldServerAuthCode = clazz->getField<JVariant_NullType_String>("serverAuthCode");
       jni::local_ref<JVariant_NullType_String> serverAuthCode = this->getFieldValue(fieldServerAuthCode);
       return OneTapAuthorizationResult(
+        accessToken != nullptr ? std::make_optional(accessToken->toCpp()) : std::nullopt,
         serverAuthCode != nullptr ? std::make_optional(serverAuthCode->toCpp()) : std::nullopt
       );
     }
@@ -49,11 +52,12 @@ namespace margelo::nitro::nitrogooglesignin {
      */
     [[maybe_unused]]
     static jni::local_ref<JOneTapAuthorizationResult::javaobject> fromCpp(const OneTapAuthorizationResult& value) {
-      using JSignature = JOneTapAuthorizationResult(jni::alias_ref<JVariant_NullType_String>);
+      using JSignature = JOneTapAuthorizationResult(jni::alias_ref<JVariant_NullType_String>, jni::alias_ref<JVariant_NullType_String>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
         clazz,
+        value.accessToken.has_value() ? JVariant_NullType_String::fromCpp(value.accessToken.value()) : nullptr,
         value.serverAuthCode.has_value() ? JVariant_NullType_String::fromCpp(value.serverAuthCode.value()) : nullptr
       );
     }

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogooglesignin/OneTapAuthorizationResult.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogooglesignin/OneTapAuthorizationResult.kt
@@ -20,6 +20,9 @@ import com.margelo.nitro.core.NullType
 data class OneTapAuthorizationResult(
   @DoNotStrip
   @Keep
+  val accessToken: Variant_NullType_String?,
+  @DoNotStrip
+  @Keep
   val serverAuthCode: Variant_NullType_String?
 ) {
   /* primary constructor */
@@ -27,11 +30,13 @@ data class OneTapAuthorizationResult(
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other !is OneTapAuthorizationResult) return false
-    return Objects.deepEquals(this.serverAuthCode, other.serverAuthCode)
+    return Objects.deepEquals(this.accessToken, other.accessToken)
+      && Objects.deepEquals(this.serverAuthCode, other.serverAuthCode)
   }
 
   override fun hashCode(): Int {
     return arrayOf<Any?>(
+      accessToken,
       serverAuthCode
     ).contentDeepHashCode()
   }
@@ -44,8 +49,8 @@ data class OneTapAuthorizationResult(
     @Keep
     @Suppress("unused")
     @JvmStatic
-    private fun fromCpp(serverAuthCode: Variant_NullType_String?): OneTapAuthorizationResult {
-      return OneTapAuthorizationResult(serverAuthCode)
+    private fun fromCpp(accessToken: Variant_NullType_String?, serverAuthCode: Variant_NullType_String?): OneTapAuthorizationResult {
+      return OneTapAuthorizationResult(accessToken, serverAuthCode)
     }
   }
 }

--- a/nitrogen/generated/ios/swift/OneTapAuthorizationResult.swift
+++ b/nitrogen/generated/ios/swift/OneTapAuthorizationResult.swift
@@ -18,8 +18,21 @@ public extension OneTapAuthorizationResult {
   /**
    * Create a new instance of `OneTapAuthorizationResult`.
    */
-  init(serverAuthCode: Variant_NullType_String?) {
+  init(accessToken: Variant_NullType_String?, serverAuthCode: Variant_NullType_String?) {
     self.init({ () -> bridge.std__optional_std__variant_nitro__NullType__std__string__ in
+      if let __unwrappedValue = accessToken {
+        return bridge.create_std__optional_std__variant_nitro__NullType__std__string__({ () -> bridge.std__variant_nitro__NullType__std__string_ in
+          switch __unwrappedValue {
+            case .first(let __value):
+              return bridge.create_std__variant_nitro__NullType__std__string_(margelo.nitro.NullType.null)
+            case .second(let __value):
+              return bridge.create_std__variant_nitro__NullType__std__string_(std.string(__value))
+          }
+        }().variant)
+      } else {
+        return .init()
+      }
+    }(), { () -> bridge.std__optional_std__variant_nitro__NullType__std__string__ in
       if let __unwrappedValue = serverAuthCode {
         return bridge.create_std__optional_std__variant_nitro__NullType__std__string__({ () -> bridge.std__variant_nitro__NullType__std__string_ in
           switch __unwrappedValue {
@@ -35,6 +48,30 @@ public extension OneTapAuthorizationResult {
     }())
   }
 
+  @inline(__always)
+  var accessToken: Variant_NullType_String? {
+    return { () -> Variant_NullType_String? in
+      if bridge.has_value_std__optional_std__variant_nitro__NullType__std__string__(self.__accessToken) {
+        let __unwrapped = bridge.get_std__optional_std__variant_nitro__NullType__std__string__(self.__accessToken)
+        return { () -> Variant_NullType_String in
+          let __variant = bridge.std__variant_nitro__NullType__std__string_(__unwrapped)
+          switch __variant.index() {
+            case 0:
+              let __actual = __variant.get_0()
+              return .first(NullType.null)
+            case 1:
+              let __actual = __variant.get_1()
+              return .second(String(__actual))
+            default:
+              fatalError("Variant can never have index \(__variant.index())!")
+          }
+        }()
+      } else {
+        return nil
+      }
+    }()
+  }
+  
   @inline(__always)
   var serverAuthCode: Variant_NullType_String? {
     return { () -> Variant_NullType_String? in

--- a/nitrogen/generated/shared/c++/OneTapAuthorizationResult.hpp
+++ b/nitrogen/generated/shared/c++/OneTapAuthorizationResult.hpp
@@ -42,11 +42,12 @@ namespace margelo::nitro::nitrogooglesignin {
    */
   struct OneTapAuthorizationResult final {
   public:
+    std::optional<std::variant<nitro::NullType, std::string>> accessToken     SWIFT_PRIVATE;
     std::optional<std::variant<nitro::NullType, std::string>> serverAuthCode     SWIFT_PRIVATE;
 
   public:
     OneTapAuthorizationResult() = default;
-    explicit OneTapAuthorizationResult(std::optional<std::variant<nitro::NullType, std::string>> serverAuthCode): serverAuthCode(serverAuthCode) {}
+    explicit OneTapAuthorizationResult(std::optional<std::variant<nitro::NullType, std::string>> accessToken, std::optional<std::variant<nitro::NullType, std::string>> serverAuthCode): accessToken(accessToken), serverAuthCode(serverAuthCode) {}
 
   public:
     friend bool operator==(const OneTapAuthorizationResult& lhs, const OneTapAuthorizationResult& rhs) = default;
@@ -62,11 +63,13 @@ namespace margelo::nitro {
     static inline margelo::nitro::nitrogooglesignin::OneTapAuthorizationResult fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
       jsi::Object obj = arg.asObject(runtime);
       return margelo::nitro::nitrogooglesignin::OneTapAuthorizationResult(
+        JSIConverter<std::optional<std::variant<nitro::NullType, std::string>>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "accessToken"))),
         JSIConverter<std::optional<std::variant<nitro::NullType, std::string>>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "serverAuthCode")))
       );
     }
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const margelo::nitro::nitrogooglesignin::OneTapAuthorizationResult& arg) {
       jsi::Object obj(runtime);
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "accessToken"), JSIConverter<std::optional<std::variant<nitro::NullType, std::string>>>::toJSI(runtime, arg.accessToken));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "serverAuthCode"), JSIConverter<std::optional<std::variant<nitro::NullType, std::string>>>::toJSI(runtime, arg.serverAuthCode));
       return obj;
     }
@@ -78,6 +81,7 @@ namespace margelo::nitro {
       if (!nitro::isPlainObject(runtime, obj)) {
         return false;
       }
+      if (!JSIConverter<std::optional<std::variant<nitro::NullType, std::string>>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "accessToken")))) return false;
       if (!JSIConverter<std::optional<std::variant<nitro::NullType, std::string>>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "serverAuthCode")))) return false;
       return true;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-google-signin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Google Sign-In and One Tap for React Native and Expo — OAuth 2.0 / OpenID Connect with Android Credential Manager and Google Sign-In SDK (iOS). Powered by Nitro Modules.",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index.js",

--- a/skills/react-native-nitro-google-signin/SKILL.md
+++ b/skills/react-native-nitro-google-signin/SKILL.md
@@ -33,7 +33,7 @@ Requires RN ≥ 0.76. **Not Expo Go** — use `expo-dev-client`.
 | ----- | ---- |
 | API | `GoogleOneTapSignIn` from `react-native-nitro-google-signin` |
 | Configure first | `GoogleOneTapSignIn.configure({ webClientId })` before sign-in |
-| `serverAuthCode` | Requires `offlineAccess: true` in `configure()` — otherwise always `null` |
+| `serverAuthCode` | Requires `offlineAccess: true` in `configure()` — otherwise always `null`. `requestScopes()` still returns `accessToken` for on-device APIs without offline access |
 | Backend | Verify every `idToken` on server (sig, `aud`, `iss`, `exp`); validate JWT `hd` if using `hostedDomain` |
 | iOS offline grant | Silent `signIn()` returns `serverAuthCode: null` — use `createAccount()` for initial code |
 | `revokeAccess` | Android: by email/id. iOS: current session only (throws if id mismatch) |

--- a/skills/react-native-nitro-google-signin/examples.md
+++ b/skills/react-native-nitro-google-signin/examples.md
@@ -22,17 +22,18 @@ await GoogleOneTapSignIn.signOut()
 
 ## Extra scopes
 
-`offlineAccess: true` in `configure()` is **required** for a non-null `serverAuthCode`:
+`requestScopes()` returns an **`accessToken`** for on-device Google API calls. Set `offlineAccess: true` in `configure()` only when you also need a non-null `serverAuthCode` for your backend:
 
 ```ts
 GoogleOneTapSignIn.configure({
   webClientId: 'YOUR_WEB_CLIENT_ID.apps.googleusercontent.com',
-  offlineAccess: true,
+  // offlineAccess: true, // optional — only for serverAuthCode
 })
 
-await GoogleOneTapSignIn.requestScopes([
+const { accessToken, serverAuthCode } = await GoogleOneTapSignIn.requestScopes([
   'https://www.googleapis.com/auth/calendar.readonly',
 ])
+// use accessToken for Google APIs from the device
 ```
 
 On **iOS**, use `createAccount()` or `presentExplicitSignIn()` (not silent `signIn()`) for the initial offline grant that returns a `serverAuthCode`.

--- a/skills/react-native-nitro-google-signin/reference.md
+++ b/skills/react-native-nitro-google-signin/reference.md
@@ -17,7 +17,7 @@ Full types: https://react-native-nitro-google-sign-in.github.io/docs/guide/api-r
 | `signIn()`                       | Android: authorized CredMan accounts; iOS: current user or restore                                   |
 | `createAccount()`                | All accounts / interactive                                                                           |
 | `presentExplicitSignIn()`        | Explicit Sign in with Google UI (Android dialog)                                                     |
-| `requestScopes(scopes)`          | `{ serverAuthCode }` after sign-in; **`offlineAccess: true` in `configure()` required** for a non-null code |
+| `requestScopes(scopes)`          | `{ accessToken, serverAuthCode }` after sign-in; **`offlineAccess: true` required only for non-null `serverAuthCode`** — use `accessToken` for on-device Google APIs |
 | `getTokens()`                      | `{ idToken, accessToken }` after sign-in; throws `SIGN_IN_REQUIRED` if not signed in |
 | `clearCachedAccessToken(token)`    | Clears cached access token (Android) or marks session for refresh (iOS) |
 | `signOut()`                      | iOS GIDSignOut; Android disables auto sign-in semantics                                              |

--- a/src/GoogleOneTapSignIn.ts
+++ b/src/GoogleOneTapSignIn.ts
@@ -80,8 +80,12 @@ export const GoogleOneTapSignIn = {
   /**
    * Request additional OAuth scopes after sign-in. User may see a consent screen.
    *
-   * Requires an active signed-in session. **`configure({ offlineAccess: true })` is required**
-   * for a non-null `serverAuthCode` in the result.
+   * Requires an active signed-in session. Returns an `accessToken` for calling Google APIs
+   * from the device. **`configure({ offlineAccess: true })` is required** for a non-null
+   * `serverAuthCode` in the result (backend offline access).
+   *
+   * Works with both the imperative API and hooks such as `useGoogleSignInFromButton`
+   * (sign in first via the hook / `signIn` / `createAccount`, then call `requestScopes`).
    *
    * @param scopes Full OAuth scope URLs (not short names).
    */

--- a/src/specs/nitro-google-signin.nitro.ts
+++ b/src/specs/nitro-google-signin.nitro.ts
@@ -99,6 +99,14 @@ export interface GetTokensResponse {
 /** Return value of {@link GoogleOneTapSignIn.requestScopes}. */
 export interface OneTapAuthorizationResult {
   /**
+   * OAuth 2.0 access token for the requested scopes.
+   *
+   * Use this to call Google APIs from the device (Drive, Calendar, etc.).
+   * Present even when `offlineAccess` is `false`. May be `null` if the user
+   * cancelled consent or authorization failed to return a token.
+   */
+  accessToken: string | null
+  /**
    * OAuth 2.0 server auth code for the requested scopes.
    *
    * **Requires `configure({ offlineAccess: true })` before calling `requestScopes()`.**

--- a/src/specs/nitro-google-signin.nitro.ts
+++ b/src/specs/nitro-google-signin.nitro.ts
@@ -102,8 +102,12 @@ export interface OneTapAuthorizationResult {
    * OAuth 2.0 access token for the requested scopes.
    *
    * Use this to call Google APIs from the device (Drive, Calendar, etc.).
-   * Present even when `offlineAccess` is `false`. May be `null` if the user
-   * cancelled consent or authorization failed to return a token.
+   * Present even when `offlineAccess` is `false`.
+   *
+   * On **iOS**, user cancel resolves with `accessToken: null` (and
+   * `serverAuthCode: null`). On **Android**, cancel throws
+   * `SIGN_IN_CANCELLED` instead of returning a null-token result; an empty
+   * authorization success also throws.
    */
   accessToken: string | null
   /**


### PR DESCRIPTION
## Summary

- **#47:** Android sign-in no longer hangs when `offlineAccess: true` is enabled. Root cause was forcing `AuthorizationRequest.Prompt.CONSENT` on every post–Credential Manager authorization (PendingIntent often never completed). Offline access now uses `requestOfflineAccess(serverClientId)` only, launches the consent UI on the main thread, and binds `setAccount` to the signed-in email.
- **#48:** `requestScopes()` shows consent and returns a usable **`accessToken`** for on-device Google APIs (Drive, etc.) without requiring `offlineAccess`. `serverAuthCode` remains `null` unless `offlineAccess: true` (expected). Empty authorization results now throw instead of silently returning `{ serverAuthCode: null }`.
- Both the imperative `GoogleOneTapSignIn` API and hooks (`useGoogleSignInFromButton` → native `signIn`/`createAccount`) share the fixed authorization path.

Fixes #47
Fixes #48

## Test plan

- [ ] **#47 (imperative):** configure with `offlineAccess: true`, `signOut`, then `signIn` / `createAccount` / `presentExplicitSignIn` — completes with success (may show consent once for offline grant)
- [ ] **#47 (hooks):** same flow via `useGoogleSignInFromButton({ behavior: 'credentialManager' })` and `buttonFlow`
- [ ] **#48 (imperative):** sign in with `offlineAccess: false`, call `requestScopes(['https://www.googleapis.com/auth/drive.file'])` — consent UI appears; result includes non-null `accessToken`, `serverAuthCode: null`
- [ ] **#48 + offlineAccess:** with `offlineAccess: true`, `requestScopes` can return both `accessToken` and `serverAuthCode`
- [ ] iOS: `requestScopes` still works; result includes `accessToken` when available
- [ ] Rebuild native app after upgrade (Metro alone is insufficient)

## Docs

- [x] Updated docs (api-reference, usage, troubleshooting) + agent skill
- [x] Docs submodule bumped


Made with [Cursor](https://cursor.com)