### PR TITLE
feat: add getCurrentUser() with granted scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ See [Usage — Access tokens](https://react-native-nitro-google-sign-in.github.i
 | `createAccount()`         | Interactive account picker (sign-up).                                                                                                            |
 | `presentExplicitSignIn()` | Explicit Sign in with Google UI. On Android, when `hostedDomain` is set, JWT `hd` is validated after sign-in (Credential Manager flows filter at request time). |
 | `requestScopes(scopes)`   | Request **additional** OAuth access after sign-in; returns `{ serverAuthCode }`. Requires `offlineAccess: true` in `configure()` for a non-null code. |
+| `getCurrentUser()`        | Sync: returns current user + granted `scopes`, or `null`. Check scopes before `requestScopes()` for existing users. |
 | `getTokens()`             | Returns `{ idToken, accessToken }` for the signed-in user. Throws `SIGN_IN_REQUIRED` if not signed in. |
 | `clearCachedAccessToken(token)` | Clears stale access token cache (Android) or marks session for refresh (iOS). Call before `getTokens()` after a 401. |
 | `signOut()`               | Clears local Google session (iOS SDK); disable auto sign-in on Android.                                                                          |

--- a/android/src/main/java/com/nitrogooglesignin/GoogleSignInController.kt
+++ b/android/src/main/java/com/nitrogooglesignin/GoogleSignInController.kt
@@ -247,12 +247,10 @@ internal object GoogleSignInController {
     val idToken = getIdTokenFromStorage(context, lastUserId) ?: return null
     val email = getEmailFromStorage(context, lastUserId)
     val storedScopes = getScopesFromStorage(context, lastUserId)
-    val scopes =
-      if (storedScopes.isEmpty()) {
-        (configuredScopes + DEFAULT_AUTHORIZATION_SCOPES).distinct().toTypedArray()
-      } else {
-        storedScopes.toTypedArray()
-      }
+    // Never fall back to configuredScopes — those may include newly added scopes the
+    // user has not consented to yet (would incorrectly skip requestScopes).
+    // Empty storage (legacy sessions) → default OIDC scopes only.
+    val scopes = (storedScopes + DEFAULT_AUTHORIZATION_SCOPES).distinct().toTypedArray()
     val profile = getProfileFromStorage(context, lastUserId)
     val claims = IdTokenClaims.parse(idToken)
 

--- a/android/src/main/java/com/nitrogooglesignin/GoogleSignInController.kt
+++ b/android/src/main/java/com/nitrogooglesignin/GoogleSignInController.kt
@@ -47,6 +47,7 @@ import com.google.android.gms.auth.api.identity.ClearTokenRequest
 import com.google.android.gms.auth.api.identity.Identity
 import com.google.android.gms.auth.api.identity.RevokeAccessRequest
 import com.google.android.gms.common.api.Scope
+import org.json.JSONObject
 
 internal object GoogleSignInController {
   private const val TAG = "GoogleSignInController"
@@ -228,6 +229,46 @@ internal object GoogleSignInController {
     return OneTapAuthorizationResult(
       accessToken = authResult.accessToken.toOptionalStringVariant(),
       serverAuthCode = authResult.serverAuthCode.toOptionalStringVariant(),
+    )
+  }
+
+  /**
+   * Returns the last signed-in user and granted scopes, or null when no session is stored.
+   * Does not require [configure] — useful on cold start before re-configuring.
+   */
+  fun getCurrentUser(): OneTapSuccessData? {
+    val context =
+      try {
+        requireContext()
+      } catch (_: Exception) {
+        return null
+      }
+    val lastUserId = getLastSignedInUserId(context) ?: return null
+    val idToken = getIdTokenFromStorage(context, lastUserId) ?: return null
+    val email = getEmailFromStorage(context, lastUserId)
+    val storedScopes = getScopesFromStorage(context, lastUserId)
+    val scopes =
+      if (storedScopes.isEmpty()) {
+        (configuredScopes + DEFAULT_AUTHORIZATION_SCOPES).distinct().toTypedArray()
+      } else {
+        storedScopes.toTypedArray()
+      }
+    val profile = getProfileFromStorage(context, lastUserId)
+    val claims = IdTokenClaims.parse(idToken)
+
+    return OneTapSuccessData(
+      user =
+        OneTapUser(
+          id = lastUserId,
+          email = (email ?: claims?.email).toOptionalStringVariant(),
+          name = (profile?.name ?: claims?.name).toOptionalStringVariant(),
+          givenName = (profile?.givenName ?: claims?.givenName).toOptionalStringVariant(),
+          familyName = (profile?.familyName ?: claims?.familyName).toOptionalStringVariant(),
+          photo = (profile?.photo ?: claims?.picture).toOptionalStringVariant(),
+        ),
+      scopes = scopes,
+      idToken = idToken,
+      serverAuthCode = null.toOptionalStringVariant(),
     )
   }
 
@@ -433,15 +474,28 @@ internal object GoogleSignInController {
         photo = googleCredential.profilePictureUri?.toString().toOptionalStringVariant(),
       )
 
-    email?.let {
-      saveEmailToStorage(requireContext(), userId, it)
-      val initialScopes = (configuredScopes + DEFAULT_AUTHORIZATION_SCOPES).toSet()
-      saveScopesToStorage(requireContext(), userId, initialScopes)
+    val initialScopes = (configuredScopes + DEFAULT_AUTHORIZATION_SCOPES).toSet()
+    if (email != null) {
+      saveEmailToStorage(requireContext(), userId, email)
+    } else {
+      saveLastSignedInUserId(requireContext(), userId)
     }
+    saveScopesToStorage(requireContext(), userId, initialScopes)
+    saveProfileToStorage(
+      requireContext(),
+      userId,
+      StoredProfile(
+        name = googleCredential.displayName,
+        givenName = googleCredential.givenName,
+        familyName = googleCredential.familyName,
+        photo = googleCredential.profilePictureUri?.toString(),
+      ),
+    )
     saveIdTokenToStorage(requireContext(), userId, googleCredential.idToken)
 
     return OneTapSuccessData(
       user = profileUser,
+      scopes = initialScopes.toTypedArray(),
       idToken = googleCredential.idToken,
       serverAuthCode = null.toOptionalStringVariant(),
     )
@@ -644,6 +698,17 @@ internal object GoogleSignInController {
     }
   }
 
+  private fun saveLastSignedInUserId(context: Context, uniqueId: String) {
+    try {
+      val prefs = getPrefs(context)
+      val encryptedUniqueId = SecureStorageHelper.encrypt(uniqueId) ?: return
+      val hashedLastSignedIn = SecureStorageHelper.hashKey("last_signed_in_user_id")
+      prefs.edit().putString(hashedLastSignedIn, encryptedUniqueId).apply()
+    } catch (e: Exception) {
+      Log.w(TAG, "Failed to save last signed-in user id", e)
+    }
+  }
+
   private fun getEmailFromStorage(context: Context, uniqueId: String): String? {
     return try {
       val prefs = getPrefs(context)
@@ -697,6 +762,54 @@ internal object GoogleSignInController {
     } catch (e: Exception) {
       null
     }
+  }
+
+  private data class StoredProfile(
+    val name: String?,
+    val givenName: String?,
+    val familyName: String?,
+    val photo: String?,
+  )
+
+  private fun saveProfileToStorage(context: Context, uniqueId: String, profile: StoredProfile) {
+    try {
+      val prefs = getPrefs(context)
+      val payload =
+        JSONObject()
+          .put("name", profile.name ?: JSONObject.NULL)
+          .put("givenName", profile.givenName ?: JSONObject.NULL)
+          .put("familyName", profile.familyName ?: JSONObject.NULL)
+          .put("photo", profile.photo ?: JSONObject.NULL)
+          .toString()
+      val encrypted = SecureStorageHelper.encrypt(payload) ?: return
+      val hashedKey = SecureStorageHelper.hashKey("${uniqueId}_profile")
+      prefs.edit().putString(hashedKey, encrypted).apply()
+    } catch (e: Exception) {
+      Log.w(TAG, "Failed to save profile to encrypted storage", e)
+    }
+  }
+
+  private fun getProfileFromStorage(context: Context, uniqueId: String): StoredProfile? {
+    return try {
+      val prefs = getPrefs(context)
+      val hashedKey = SecureStorageHelper.hashKey("${uniqueId}_profile")
+      val encrypted = prefs.getString(hashedKey, null) ?: return null
+      val decrypted = SecureStorageHelper.decrypt(encrypted) ?: return null
+      val json = JSONObject(decrypted)
+      StoredProfile(
+        name = json.optStringOrNull("name"),
+        givenName = json.optStringOrNull("givenName"),
+        familyName = json.optStringOrNull("familyName"),
+        photo = json.optStringOrNull("photo"),
+      )
+    } catch (e: Exception) {
+      null
+    }
+  }
+
+  private fun JSONObject.optStringOrNull(key: String): String? {
+    if (!has(key) || isNull(key)) return null
+    return optString(key).takeIf { it.isNotEmpty() }
   }
 
   private fun saveScopesToStorage(context: Context, uniqueId: String, scopes: Set<String>) {
@@ -757,6 +870,7 @@ internal object GoogleSignInController {
         editor.remove(SecureStorageHelper.hashKey(it))
         editor.remove(SecureStorageHelper.hashKey("${it}_scopes"))
         editor.remove(SecureStorageHelper.hashKey("${it}_id_token"))
+        editor.remove(SecureStorageHelper.hashKey("${it}_profile"))
       }
       editor.remove(SecureStorageHelper.hashKey("last_signed_in_user_id"))
       editor.apply()

--- a/android/src/main/java/com/nitrogooglesignin/HybridNitroGoogleSignin.kt
+++ b/android/src/main/java/com/nitrogooglesignin/HybridNitroGoogleSignin.kt
@@ -2,12 +2,14 @@ package com.nitrogooglesignin
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.NullType
 import com.margelo.nitro.core.Promise
 import com.margelo.nitro.nitrogooglesignin.HybridNitroGoogleSigninSpec
 import com.margelo.nitro.nitrogooglesignin.GetTokensResponse
 import com.margelo.nitro.nitrogooglesignin.OneTapAuthorizationResult
 import com.margelo.nitro.nitrogooglesignin.OneTapConfigureParams
 import com.margelo.nitro.nitrogooglesignin.OneTapResponse
+import com.margelo.nitro.nitrogooglesignin.Variant_NullType_OneTapSuccessData
 import com.nitrogooglesignin.GoogleSignInController
 
 /**
@@ -37,6 +39,15 @@ class HybridNitroGoogleSignin : HybridNitroGoogleSigninSpec() {
 
   override fun requestScopes(scopes: Array<String>): Promise<OneTapAuthorizationResult> =
     Promise.async { GoogleSignInController.requestScopes(scopes) }
+
+  override fun getCurrentUser(): Variant_NullType_OneTapSuccessData {
+    val user = GoogleSignInController.getCurrentUser()
+    return if (user == null) {
+      Variant_NullType_OneTapSuccessData.create(NullType.NULL)
+    } else {
+      Variant_NullType_OneTapSuccessData.create(user)
+    }
+  }
 
   override fun getTokens(): Promise<GetTokensResponse> =
     Promise.async { GoogleSignInController.getTokens() }

--- a/android/src/main/java/com/nitrogooglesignin/IdTokenClaims.kt
+++ b/android/src/main/java/com/nitrogooglesignin/IdTokenClaims.kt
@@ -8,6 +8,10 @@ internal data class IdTokenClaims(
   val email: String?,
   /** Google Workspace hosted domain (`hd` claim). Present only for Workspace accounts. */
   val hd: String?,
+  val name: String?,
+  val givenName: String?,
+  val familyName: String?,
+  val picture: String?,
 ) {
   companion object {
     fun parse(idToken: String): IdTokenClaims? =
@@ -23,6 +27,10 @@ internal data class IdTokenClaims(
           sub = json.optString("sub").takeIf { it.isNotEmpty() },
           email = json.optString("email").takeIf { it.isNotEmpty() },
           hd = json.optString("hd").takeIf { it.isNotEmpty() },
+          name = json.optString("name").takeIf { it.isNotEmpty() },
+          givenName = json.optString("given_name").takeIf { it.isNotEmpty() },
+          familyName = json.optString("family_name").takeIf { it.isNotEmpty() },
+          picture = json.optString("picture").takeIf { it.isNotEmpty() },
         )
       } catch (_: Exception) {
         null

--- a/example-expo/App.tsx
+++ b/example-expo/App.tsx
@@ -54,6 +54,9 @@ export default function App() {
   )
   const [tokensStatus, setTokensStatus] = useState<string | null>(null)
   const [lastAccessToken, setLastAccessToken] = useState<string | null>(null)
+  const [currentUserStatus, setCurrentUserStatus] = useState<string | null>(
+    null
+  )
 
   useEffect(() => {
     GoogleOneTapSignIn.configure({
@@ -66,6 +69,7 @@ export default function App() {
     setUser(data)
     setTokensStatus(null)
     setLastAccessToken(null)
+    setCurrentUserStatus(null)
     setStatus(`Signed in as ${data.user.email ?? data.user.id}`)
   }
 
@@ -128,6 +132,17 @@ export default function App() {
     }
   }
 
+  const getCurrentUser = () => {
+    const current = GoogleOneTapSignIn.getCurrentUser()
+    if (!current) {
+      setCurrentUserStatus('getCurrentUser() → null (not signed in)')
+      return
+    }
+    setCurrentUserStatus(
+      `getCurrentUser() → ${current.user.email ?? current.user.id}; scopes: ${current.scopes.join(', ') || '(none)'}`
+    )
+  }
+
   const getTokens = async () => {
     if (!user) {
       setTokensStatus('Sign in first, then call getTokens().')
@@ -182,6 +197,7 @@ export default function App() {
       setExtraScopesStatus(null)
       setTokensStatus(null)
       setLastAccessToken(null)
+      setCurrentUserStatus(null)
       setStatus('Signed out')
     } catch (e) {
       setStatus(formatGoogleSignInError(e, 'Sign out failed'))
@@ -199,6 +215,7 @@ export default function App() {
       setExtraScopesStatus(null)
       setTokensStatus(null)
       setLastAccessToken(null)
+      setCurrentUserStatus(null)
       setStatus('Access revoked')
     } catch (e) {
       setStatus(formatGoogleSignInError(e, 'Revoke access failed'))
@@ -236,6 +253,10 @@ export default function App() {
 
         {tokensStatus ? <Text style={styles.hint}>{tokensStatus}</Text> : null}
 
+        {currentUserStatus ? (
+          <Text style={styles.hint}>{currentUserStatus}</Text>
+        ) : null}
+
         {!isSignedIn ? (
           <View style={styles.signInButtonContainer} collapsable={false}>
             <GoogleSignInButton
@@ -270,6 +291,13 @@ export default function App() {
               style={[styles.action, loading && styles.actionDisabled]}
             >
               Get tokens
+            </Text>
+            <Text
+              accessibilityRole="button"
+              onPress={loading ? undefined : getCurrentUser}
+              style={[styles.action, loading && styles.actionDisabled]}
+            >
+              Get current user
             </Text>
             <Text
               accessibilityRole="button"

--- a/example-expo/App.tsx
+++ b/example-expo/App.tsx
@@ -23,6 +23,25 @@ const DRIVE_FULL_SCOPE = 'https://www.googleapis.com/auth/drive'
 
 const WEB_CLIENT_ID = process.env.EXPO_PUBLIC_WEB_CLIENT_ID ?? ''
 
+/** Prefix for Metro / logcat filtering while verifying getCurrentUser + scopes. */
+const LOG_TAG = '[GoogleSignIn:getCurrentUser]'
+
+function logCurrentUser(label: string, data: OneTapSuccessData | null): void {
+  if (!data) {
+    console.log(LOG_TAG, label, '→ null')
+    return
+  }
+  console.log(LOG_TAG, label, {
+    id: data.user.id,
+    email: data.user.email,
+    name: data.user.name,
+    scopes: data.scopes,
+    scopesCount: data.scopes.length,
+    hasIdToken: Boolean(data.idToken),
+    serverAuthCode: data.serverAuthCode,
+  })
+}
+
 function formatGoogleSignInError(error: unknown, fallback: string): string {
   if (isErrorWithCode(error)) {
     return `${error.code}: ${error.message}`
@@ -63,9 +82,18 @@ export default function App() {
       webClientId: WEB_CLIENT_ID,
       offlineAccess: false,
     })
+    logCurrentUser(
+      'getCurrentUser() on mount (after configure)',
+      GoogleOneTapSignIn.getCurrentUser()
+    )
   }, [])
 
   const onSignInSuccess = (data: OneTapSuccessData) => {
+    logCurrentUser('onSignInSuccess (response.data)', data)
+    logCurrentUser(
+      'getCurrentUser() right after sign-in',
+      GoogleOneTapSignIn.getCurrentUser()
+    )
     setUser(data)
     setTokensStatus(null)
     setLastAccessToken(null)
@@ -107,8 +135,20 @@ export default function App() {
 
     setLoading(true)
     setExtraScopesStatus('Requesting Drive full access…')
+    logCurrentUser(
+      'getCurrentUser() before requestScopes',
+      GoogleOneTapSignIn.getCurrentUser()
+    )
     try {
       const result = await GoogleOneTapSignIn.requestScopes([DRIVE_FULL_SCOPE])
+      console.log(LOG_TAG, 'requestScopes result', {
+        hasAccessToken: Boolean(result.accessToken),
+        serverAuthCode: result.serverAuthCode,
+      })
+      logCurrentUser(
+        'getCurrentUser() after requestScopes (expect Drive scope)',
+        GoogleOneTapSignIn.getCurrentUser()
+      )
       if (result.accessToken) {
         const authHint = result.serverAuthCode
           ? `access token + server auth code (${result.serverAuthCode.slice(0, 12)}…)`
@@ -127,6 +167,7 @@ export default function App() {
       setExtraScopesStatus(
         formatGoogleSignInError(e, 'Failed to request scopes')
       )
+      console.log(LOG_TAG, 'requestAdditionalScopes error', e)
     } finally {
       setLoading(false)
     }
@@ -134,6 +175,7 @@ export default function App() {
 
   const getCurrentUser = () => {
     const current = GoogleOneTapSignIn.getCurrentUser()
+    logCurrentUser('Get current user button', current)
     if (!current) {
       setCurrentUserStatus('getCurrentUser() → null (not signed in)')
       return
@@ -193,6 +235,10 @@ export default function App() {
       setLoading(true)
       setStatus('Signing out…')
       await GoogleOneTapSignIn.signOut()
+      logCurrentUser(
+        'getCurrentUser() after signOut (expect null)',
+        GoogleOneTapSignIn.getCurrentUser()
+      )
       setUser(null)
       setExtraScopesStatus(null)
       setTokensStatus(null)
@@ -211,6 +257,10 @@ export default function App() {
       setLoading(true)
       setStatus('Revoking access…')
       await GoogleOneTapSignIn.revokeAccess(user?.user.id ?? '')
+      logCurrentUser(
+        'getCurrentUser() after revokeAccess (expect null)',
+        GoogleOneTapSignIn.getCurrentUser()
+      )
       setUser(null)
       setExtraScopesStatus(null)
       setTokensStatus(null)

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -23,6 +23,25 @@ const WEB_CLIENT_ID = Config.WEB_CLIENT_ID;
 
 const DRIVE_FULL_SCOPE = 'https://www.googleapis.com/auth/drive';
 
+/** Prefix for Metro / logcat filtering while verifying getCurrentUser + scopes. */
+const LOG_TAG = '[GoogleSignIn:getCurrentUser]';
+
+function logCurrentUser(label: string, data: OneTapSuccessData | null): void {
+  if (!data) {
+    console.log(LOG_TAG, label, '→ null');
+    return;
+  }
+  console.log(LOG_TAG, label, {
+    id: data.user.id,
+    email: data.user.email,
+    name: data.user.name,
+    scopes: data.scopes,
+    scopesCount: data.scopes.length,
+    hasIdToken: Boolean(data.idToken),
+    serverAuthCode: data.serverAuthCode,
+  });
+}
+
 function formatGoogleSignInError(error: unknown, fallback: string): string {
   if (isErrorWithCode(error)) {
     return `${error.code}: ${error.message}`;
@@ -63,9 +82,18 @@ function App(): React.JSX.Element {
       webClientId: WEB_CLIENT_ID,
       offlineAccess: true,
     });
+    logCurrentUser(
+      'getCurrentUser() on mount (after configure)',
+      GoogleOneTapSignIn.getCurrentUser(),
+    );
   }, []);
 
   const onSignInSuccess = (data: OneTapSuccessData) => {
+    logCurrentUser('onSignInSuccess (response.data)', data);
+    logCurrentUser(
+      'getCurrentUser() right after sign-in',
+      GoogleOneTapSignIn.getCurrentUser(),
+    );
     setUser(data);
     setTokensStatus(null);
     setLastAccessToken(null);
@@ -107,8 +135,20 @@ function App(): React.JSX.Element {
 
     setLoading(true);
     setExtraScopesStatus('Requesting Drive full access…');
+    logCurrentUser(
+      'getCurrentUser() before requestScopes',
+      GoogleOneTapSignIn.getCurrentUser(),
+    );
     try {
       const result = await GoogleOneTapSignIn.requestScopes([DRIVE_FULL_SCOPE]);
+      console.log(LOG_TAG, 'requestScopes result', {
+        hasAccessToken: Boolean(result.accessToken),
+        serverAuthCode: result.serverAuthCode,
+      });
+      logCurrentUser(
+        'getCurrentUser() after requestScopes (expect Drive scope)',
+        GoogleOneTapSignIn.getCurrentUser(),
+      );
 
       if (result.accessToken) {
         const authHint = result.serverAuthCode
@@ -128,7 +168,7 @@ function App(): React.JSX.Element {
       setExtraScopesStatus(
         formatGoogleSignInError(e, 'Failed to request scopes'),
       );
-      console.log('requestAdditionalScopes error', e, (e as Error).name);
+      console.log(LOG_TAG, 'requestAdditionalScopes error', e, (e as Error).name);
     } finally {
       setLoading(false);
     }
@@ -136,6 +176,7 @@ function App(): React.JSX.Element {
 
   const getCurrentUser = () => {
     const current = GoogleOneTapSignIn.getCurrentUser();
+    logCurrentUser('Get current user button', current);
     if (!current) {
       setCurrentUserStatus('getCurrentUser() → null (not signed in)');
       return;
@@ -195,6 +236,10 @@ function App(): React.JSX.Element {
       setLoading(true);
       setStatus('Signing out…');
       await GoogleOneTapSignIn.signOut();
+      logCurrentUser(
+        'getCurrentUser() after signOut (expect null)',
+        GoogleOneTapSignIn.getCurrentUser(),
+      );
       setUser(null);
       setExtraScopesStatus(null);
       setTokensStatus(null);
@@ -213,6 +258,10 @@ function App(): React.JSX.Element {
       setLoading(true);
       setStatus('Revoking access…');
       await GoogleOneTapSignIn.revokeAccess(user?.user.id ?? '');
+      logCurrentUser(
+        'getCurrentUser() after revokeAccess (expect null)',
+        GoogleOneTapSignIn.getCurrentUser(),
+      );
       setUser(null);
       setExtraScopesStatus(null);
       setTokensStatus(null);

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -54,6 +54,9 @@ function App(): React.JSX.Element {
   );
   const [tokensStatus, setTokensStatus] = useState<string | null>(null);
   const [lastAccessToken, setLastAccessToken] = useState<string | null>(null);
+  const [currentUserStatus, setCurrentUserStatus] = useState<string | null>(
+    null,
+  );
 
   useEffect(() => {
     GoogleOneTapSignIn.configure({
@@ -66,6 +69,7 @@ function App(): React.JSX.Element {
     setUser(data);
     setTokensStatus(null);
     setLastAccessToken(null);
+    setCurrentUserStatus(null);
     setStatus(`Signed in as ${data.user.email ?? data.user.id}`);
   };
 
@@ -130,6 +134,17 @@ function App(): React.JSX.Element {
     }
   };
 
+  const getCurrentUser = () => {
+    const current = GoogleOneTapSignIn.getCurrentUser();
+    if (!current) {
+      setCurrentUserStatus('getCurrentUser() → null (not signed in)');
+      return;
+    }
+    setCurrentUserStatus(
+      `getCurrentUser() → ${current.user.email ?? current.user.id}; scopes: ${current.scopes.join(', ') || '(none)'}`,
+    );
+  };
+
   const getTokens = async () => {
     if (!user) {
       setTokensStatus('Sign in first, then call getTokens().');
@@ -184,6 +199,7 @@ function App(): React.JSX.Element {
       setExtraScopesStatus(null);
       setTokensStatus(null);
       setLastAccessToken(null);
+      setCurrentUserStatus(null);
       setStatus('Signed out');
     } catch (e) {
       setStatus(formatGoogleSignInError(e, 'Sign out failed'));
@@ -201,6 +217,7 @@ function App(): React.JSX.Element {
       setExtraScopesStatus(null);
       setTokensStatus(null);
       setLastAccessToken(null);
+      setCurrentUserStatus(null);
       setStatus('Access revoked');
     } catch (e) {
       setStatus(formatGoogleSignInError(e, 'Revoke access failed'));
@@ -236,6 +253,10 @@ function App(): React.JSX.Element {
 
       {tokensStatus ? <Text style={styles.hint}>{tokensStatus}</Text> : null}
 
+      {currentUserStatus ? (
+        <Text style={styles.hint}>{currentUserStatus}</Text>
+      ) : null}
+
       {!isSignedIn ? (
         <View style={styles.signInButtonContainer} collapsable={false}>
           <GoogleSignInButton
@@ -270,6 +291,13 @@ function App(): React.JSX.Element {
             style={[styles.action, loading && styles.actionDisabled]}
           >
             Get tokens
+          </Text>
+          <Text
+            accessibilityRole="button"
+            onPress={loading ? undefined : getCurrentUser}
+            style={[styles.action, loading && styles.actionDisabled]}
+          >
+            Get current user
           </Text>
           <Text
             accessibilityRole="button"

--- a/ios/HybridNitroGoogleSignin.swift
+++ b/ios/HybridNitroGoogleSignin.swift
@@ -160,6 +160,13 @@ class HybridNitroGoogleSignin: HybridNitroGoogleSigninSpec {
     }
   }
 
+  func getCurrentUser() throws -> Variant_NullType_OneTapSuccessData {
+    if let user = GIDSignIn.sharedInstance.currentUser {
+      return .second(Self.successData(from: user, serverAuthCode: nil))
+    }
+    return .first(NullType.null)
+  }
+
   func getTokens() throws -> Promise<GetTokensResponse> {
     try ensureConfigured()
     return Promise.async {
@@ -242,6 +249,11 @@ class HybridNitroGoogleSignin: HybridNitroGoogleSigninSpec {
   // MARK: - Mapping
 
   private static func success(from user: GIDGoogleUser, serverAuthCode: String?) -> OneTapResponse {
+    let data = successData(from: user, serverAuthCode: serverAuthCode)
+    return OneTapResponse(type: .success, data: .second(data))
+  }
+
+  private static func successData(from user: GIDGoogleUser, serverAuthCode: String?) -> OneTapSuccessData {
     let profile = user.profile
     let oneTapUser = OneTapUser(
       id: user.userID ?? "",
@@ -251,12 +263,13 @@ class HybridNitroGoogleSignin: HybridNitroGoogleSigninSpec {
       familyName: optionalStringVariant(profile?.familyName),
       photo: optionalStringVariant(profile?.imageURL(withDimension: 320)?.absoluteString)
     )
-    let data = OneTapSuccessData(
+    let scopes = user.grantedScopes ?? []
+    return OneTapSuccessData(
       user: oneTapUser,
+      scopes: scopes,
       idToken: user.idToken?.tokenString ?? "",
       serverAuthCode: optionalStringVariant(serverAuthCode)
     )
-    return OneTapResponse(type: .success, data: .second(data))
   }
 
   private static func noSavedCredential() -> OneTapResponse {

--- a/nitrogen/generated/android/c++/JHybridNitroGoogleSigninSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridNitroGoogleSigninSpec.cpp
@@ -40,13 +40,13 @@ namespace margelo::nitro::nitrogooglesignin { struct OneTapConfigureParams; }
 #include "JOneTapUser.hpp"
 #include <string>
 #include "JVariant_NullType_String.hpp"
+#include <vector>
 #include "OneTapAuthorizationResult.hpp"
 #include "JOneTapAuthorizationResult.hpp"
 #include "GetTokensResponse.hpp"
 #include "JGetTokensResponse.hpp"
 #include "OneTapConfigureParams.hpp"
 #include "JOneTapConfigureParams.hpp"
-#include <vector>
 #include "JVariant_NullType_Array_String_.hpp"
 
 namespace margelo::nitro::nitrogooglesignin {
@@ -173,6 +173,11 @@ namespace margelo::nitro::nitrogooglesignin {
       });
       return __promise;
     }();
+  }
+  std::variant<nitro::NullType, OneTapSuccessData> JHybridNitroGoogleSigninSpec::getCurrentUser() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JVariant_NullType_OneTapSuccessData>()>("getCurrentUser");
+    auto __result = method(_javaPart);
+    return __result->toCpp();
   }
   std::shared_ptr<Promise<GetTokensResponse>> JHybridNitroGoogleSigninSpec::getTokens() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("getTokens");

--- a/nitrogen/generated/android/c++/JHybridNitroGoogleSigninSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridNitroGoogleSigninSpec.hpp
@@ -60,6 +60,7 @@ namespace margelo::nitro::nitrogooglesignin {
     std::shared_ptr<Promise<OneTapResponse>> createAccount() override;
     std::shared_ptr<Promise<OneTapResponse>> presentExplicitSignIn() override;
     std::shared_ptr<Promise<OneTapAuthorizationResult>> requestScopes(const std::vector<std::string>& scopes) override;
+    std::variant<nitro::NullType, OneTapSuccessData> getCurrentUser() override;
     std::shared_ptr<Promise<GetTokensResponse>> getTokens() override;
     std::shared_ptr<Promise<void>> clearCachedAccessToken(const std::string& accessTokenString) override;
     std::shared_ptr<Promise<void>> signOut() override;

--- a/nitrogen/generated/android/c++/JOneTapResponse.hpp
+++ b/nitrogen/generated/android/c++/JOneTapResponse.hpp
@@ -23,6 +23,7 @@
 #include <optional>
 #include <string>
 #include <variant>
+#include <vector>
 
 namespace margelo::nitro::nitrogooglesignin {
 

--- a/nitrogen/generated/android/c++/JOneTapSuccessData.hpp
+++ b/nitrogen/generated/android/c++/JOneTapSuccessData.hpp
@@ -18,6 +18,7 @@
 #include <optional>
 #include <string>
 #include <variant>
+#include <vector>
 
 namespace margelo::nitro::nitrogooglesignin {
 
@@ -40,12 +41,24 @@ namespace margelo::nitro::nitrogooglesignin {
       static const auto clazz = javaClassStatic();
       static const auto fieldUser = clazz->getField<JOneTapUser>("user");
       jni::local_ref<JOneTapUser> user = this->getFieldValue(fieldUser);
+      static const auto fieldScopes = clazz->getField<jni::JArrayClass<jni::JString>>("scopes");
+      jni::local_ref<jni::JArrayClass<jni::JString>> scopes = this->getFieldValue(fieldScopes);
       static const auto fieldIdToken = clazz->getField<jni::JString>("idToken");
       jni::local_ref<jni::JString> idToken = this->getFieldValue(fieldIdToken);
       static const auto fieldServerAuthCode = clazz->getField<JVariant_NullType_String>("serverAuthCode");
       jni::local_ref<JVariant_NullType_String> serverAuthCode = this->getFieldValue(fieldServerAuthCode);
       return OneTapSuccessData(
         user->toCpp(),
+        [&](auto&& __input) {
+          size_t __size = __input->size();
+          std::vector<std::string> __vector;
+          __vector.reserve(__size);
+          for (size_t __i = 0; __i < __size; __i++) {
+            auto __element = __input->getElement(__i);
+            __vector.push_back(__element->toStdString());
+          }
+          return __vector;
+        }(scopes),
         idToken->toStdString(),
         serverAuthCode != nullptr ? std::make_optional(serverAuthCode->toCpp()) : std::nullopt
       );
@@ -57,12 +70,22 @@ namespace margelo::nitro::nitrogooglesignin {
      */
     [[maybe_unused]]
     static jni::local_ref<JOneTapSuccessData::javaobject> fromCpp(const OneTapSuccessData& value) {
-      using JSignature = JOneTapSuccessData(jni::alias_ref<JOneTapUser>, jni::alias_ref<jni::JString>, jni::alias_ref<JVariant_NullType_String>);
+      using JSignature = JOneTapSuccessData(jni::alias_ref<JOneTapUser>, jni::alias_ref<jni::JArrayClass<jni::JString>>, jni::alias_ref<jni::JString>, jni::alias_ref<JVariant_NullType_String>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
         clazz,
         JOneTapUser::fromCpp(value.user),
+        [&](auto&& __input) {
+          size_t __size = __input.size();
+          jni::local_ref<jni::JArrayClass<jni::JString>> __array = jni::JArrayClass<jni::JString>::newArray(__size);
+          for (size_t __i = 0; __i < __size; __i++) {
+            const auto& __element = __input[__i];
+            auto __elementJni = jni::make_jstring(__element);
+            __array->setElement(__i, *__elementJni);
+          }
+          return __array;
+        }(value.scopes),
         jni::make_jstring(value.idToken),
         value.serverAuthCode.has_value() ? JVariant_NullType_String::fromCpp(value.serverAuthCode.value()) : nullptr
       );

--- a/nitrogen/generated/android/c++/JVariant_NullType_OneTapSuccessData.hpp
+++ b/nitrogen/generated/android/c++/JVariant_NullType_OneTapSuccessData.hpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <optional>
 #include "JVariant_NullType_String.hpp"
+#include <vector>
 
 namespace margelo::nitro::nitrogooglesignin {
 

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogooglesignin/HybridNitroGoogleSigninSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogooglesignin/HybridNitroGoogleSigninSpec.kt
@@ -11,6 +11,7 @@ import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.Promise
+import com.margelo.nitro.core.NullType
 import com.margelo.nitro.core.HybridObject
 
 /**
@@ -52,6 +53,10 @@ abstract class HybridNitroGoogleSigninSpec: HybridObject() {
   @DoNotStrip
   @Keep
   abstract fun requestScopes(scopes: Array<String>): Promise<OneTapAuthorizationResult>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun getCurrentUser(): Variant_NullType_OneTapSuccessData
   
   @DoNotStrip
   @Keep

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogooglesignin/OneTapSuccessData.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogooglesignin/OneTapSuccessData.kt
@@ -23,6 +23,9 @@ data class OneTapSuccessData(
   val user: OneTapUser,
   @DoNotStrip
   @Keep
+  val scopes: Array<String>,
+  @DoNotStrip
+  @Keep
   val idToken: String,
   @DoNotStrip
   @Keep
@@ -34,6 +37,7 @@ data class OneTapSuccessData(
     if (this === other) return true
     if (other !is OneTapSuccessData) return false
     return Objects.deepEquals(this.user, other.user)
+      && Objects.deepEquals(this.scopes, other.scopes)
       && Objects.deepEquals(this.idToken, other.idToken)
       && Objects.deepEquals(this.serverAuthCode, other.serverAuthCode)
   }
@@ -41,6 +45,7 @@ data class OneTapSuccessData(
   override fun hashCode(): Int {
     return arrayOf<Any?>(
       user,
+      scopes,
       idToken,
       serverAuthCode
     ).contentDeepHashCode()
@@ -54,8 +59,8 @@ data class OneTapSuccessData(
     @Keep
     @Suppress("unused")
     @JvmStatic
-    private fun fromCpp(user: OneTapUser, idToken: String, serverAuthCode: Variant_NullType_String?): OneTapSuccessData {
-      return OneTapSuccessData(user, idToken, serverAuthCode)
+    private fun fromCpp(user: OneTapUser, scopes: Array<String>, idToken: String, serverAuthCode: Variant_NullType_String?): OneTapSuccessData {
+      return OneTapSuccessData(user, scopes, idToken, serverAuthCode)
     }
   }
 }

--- a/nitrogen/generated/ios/NitroGoogleSignin-Swift-Cxx-Bridge.hpp
+++ b/nitrogen/generated/ios/NitroGoogleSignin-Swift-Cxx-Bridge.hpp
@@ -452,6 +452,15 @@ namespace margelo::nitro::nitrogooglesignin::bridge::swift {
     return Result<std::shared_ptr<Promise<OneTapAuthorizationResult>>>::withError(error);
   }
   
+  // pragma MARK: Result<std::variant<nitro::NullType, OneTapSuccessData>>
+  using Result_std__variant_nitro__NullType__OneTapSuccessData__ = Result<std::variant<nitro::NullType, OneTapSuccessData>>;
+  inline Result_std__variant_nitro__NullType__OneTapSuccessData__ create_Result_std__variant_nitro__NullType__OneTapSuccessData__(const std::variant<nitro::NullType, OneTapSuccessData>& value) noexcept {
+    return Result<std::variant<nitro::NullType, OneTapSuccessData>>::withValue(value);
+  }
+  inline Result_std__variant_nitro__NullType__OneTapSuccessData__ create_Result_std__variant_nitro__NullType__OneTapSuccessData__(const std::exception_ptr& error) noexcept {
+    return Result<std::variant<nitro::NullType, OneTapSuccessData>>::withError(error);
+  }
+  
   // pragma MARK: Result<std::shared_ptr<Promise<GetTokensResponse>>>
   using Result_std__shared_ptr_Promise_GetTokensResponse___ = Result<std::shared_ptr<Promise<GetTokensResponse>>>;
   inline Result_std__shared_ptr_Promise_GetTokensResponse___ create_Result_std__shared_ptr_Promise_GetTokensResponse___(const std::shared_ptr<Promise<GetTokensResponse>>& value) noexcept {

--- a/nitrogen/generated/ios/c++/HybridNitroGoogleSigninSpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridNitroGoogleSigninSpecSwift.hpp
@@ -137,6 +137,14 @@ namespace margelo::nitro::nitrogooglesignin {
       auto __value = std::move(__result.value());
       return __value;
     }
+    inline std::variant<nitro::NullType, OneTapSuccessData> getCurrentUser() override {
+      auto __result = _swiftPart.getCurrentUser();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline std::shared_ptr<Promise<GetTokensResponse>> getTokens() override {
       auto __result = _swiftPart.getTokens();
       if (__result.hasError()) [[unlikely]] {

--- a/nitrogen/generated/ios/swift/HybridNitroGoogleSigninSpec.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroGoogleSigninSpec.swift
@@ -19,6 +19,7 @@ public protocol HybridNitroGoogleSigninSpec_protocol: HybridObject {
   func createAccount() throws -> Promise<OneTapResponse>
   func presentExplicitSignIn() throws -> Promise<OneTapResponse>
   func requestScopes(scopes: [String]) throws -> Promise<OneTapAuthorizationResult>
+  func getCurrentUser() throws -> Variant_NullType_OneTapSuccessData
   func getTokens() throws -> Promise<GetTokensResponse>
   func clearCachedAccessToken(accessTokenString: String) throws -> Promise<Void>
   func signOut() throws -> Promise<Void>

--- a/nitrogen/generated/ios/swift/HybridNitroGoogleSigninSpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroGoogleSigninSpec_cxx.swift
@@ -238,6 +238,25 @@ open class HybridNitroGoogleSigninSpec_cxx {
   }
   
   @inline(__always)
+  public final func getCurrentUser() -> bridge.Result_std__variant_nitro__NullType__OneTapSuccessData__ {
+    do {
+      let __result = try self.__implementation.getCurrentUser()
+      let __resultCpp = { () -> bridge.std__variant_nitro__NullType__OneTapSuccessData_ in
+        switch __result {
+          case .first(let __value):
+            return bridge.create_std__variant_nitro__NullType__OneTapSuccessData_(margelo.nitro.NullType.null)
+          case .second(let __value):
+            return bridge.create_std__variant_nitro__NullType__OneTapSuccessData_(__value)
+        }
+      }().variant
+      return bridge.create_Result_std__variant_nitro__NullType__OneTapSuccessData__(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__variant_nitro__NullType__OneTapSuccessData__(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func getTokens() -> bridge.Result_std__shared_ptr_Promise_GetTokensResponse___ {
     do {
       let __result = try self.__implementation.getTokens()

--- a/nitrogen/generated/ios/swift/OneTapSuccessData.swift
+++ b/nitrogen/generated/ios/swift/OneTapSuccessData.swift
@@ -18,8 +18,14 @@ public extension OneTapSuccessData {
   /**
    * Create a new instance of `OneTapSuccessData`.
    */
-  init(user: OneTapUser, idToken: String, serverAuthCode: Variant_NullType_String?) {
-    self.init(user, std.string(idToken), { () -> bridge.std__optional_std__variant_nitro__NullType__std__string__ in
+  init(user: OneTapUser, scopes: [String], idToken: String, serverAuthCode: Variant_NullType_String?) {
+    self.init(user, { () -> bridge.std__vector_std__string_ in
+      var __vector = bridge.create_std__vector_std__string_(scopes.count)
+      for __item in scopes {
+        __vector.push_back(std.string(__item))
+      }
+      return __vector
+    }(), std.string(idToken), { () -> bridge.std__optional_std__variant_nitro__NullType__std__string__ in
       if let __unwrappedValue = serverAuthCode {
         return bridge.create_std__optional_std__variant_nitro__NullType__std__string__({ () -> bridge.std__variant_nitro__NullType__std__string_ in
           switch __unwrappedValue {
@@ -38,6 +44,11 @@ public extension OneTapSuccessData {
   @inline(__always)
   var user: OneTapUser {
     return self.__user
+  }
+  
+  @inline(__always)
+  var scopes: [String] {
+    return self.__scopes.map({ __item in String(__item) })
   }
   
   @inline(__always)

--- a/nitrogen/generated/shared/c++/HybridNitroGoogleSigninSpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridNitroGoogleSigninSpec.cpp
@@ -20,6 +20,7 @@ namespace margelo::nitro::nitrogooglesignin {
       prototype.registerHybridMethod("createAccount", &HybridNitroGoogleSigninSpec::createAccount);
       prototype.registerHybridMethod("presentExplicitSignIn", &HybridNitroGoogleSigninSpec::presentExplicitSignIn);
       prototype.registerHybridMethod("requestScopes", &HybridNitroGoogleSigninSpec::requestScopes);
+      prototype.registerHybridMethod("getCurrentUser", &HybridNitroGoogleSigninSpec::getCurrentUser);
       prototype.registerHybridMethod("getTokens", &HybridNitroGoogleSigninSpec::getTokens);
       prototype.registerHybridMethod("clearCachedAccessToken", &HybridNitroGoogleSigninSpec::clearCachedAccessToken);
       prototype.registerHybridMethod("signOut", &HybridNitroGoogleSigninSpec::signOut);

--- a/nitrogen/generated/shared/c++/HybridNitroGoogleSigninSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridNitroGoogleSigninSpec.hpp
@@ -19,6 +19,8 @@ namespace margelo::nitro::nitrogooglesignin { struct OneTapConfigureParams; }
 namespace margelo::nitro::nitrogooglesignin { struct OneTapResponse; }
 // Forward declaration of `OneTapAuthorizationResult` to properly resolve imports.
 namespace margelo::nitro::nitrogooglesignin { struct OneTapAuthorizationResult; }
+// Forward declaration of `OneTapSuccessData` to properly resolve imports.
+namespace margelo::nitro::nitrogooglesignin { struct OneTapSuccessData; }
 // Forward declaration of `GetTokensResponse` to properly resolve imports.
 namespace margelo::nitro::nitrogooglesignin { struct GetTokensResponse; }
 
@@ -29,6 +31,9 @@ namespace margelo::nitro::nitrogooglesignin { struct GetTokensResponse; }
 #include "OneTapAuthorizationResult.hpp"
 #include <string>
 #include <vector>
+#include <NitroModules/Null.hpp>
+#include "OneTapSuccessData.hpp"
+#include <variant>
 #include "GetTokensResponse.hpp"
 
 namespace margelo::nitro::nitrogooglesignin {
@@ -68,6 +73,7 @@ namespace margelo::nitro::nitrogooglesignin {
       virtual std::shared_ptr<Promise<OneTapResponse>> createAccount() = 0;
       virtual std::shared_ptr<Promise<OneTapResponse>> presentExplicitSignIn() = 0;
       virtual std::shared_ptr<Promise<OneTapAuthorizationResult>> requestScopes(const std::vector<std::string>& scopes) = 0;
+      virtual std::variant<nitro::NullType, OneTapSuccessData> getCurrentUser() = 0;
       virtual std::shared_ptr<Promise<GetTokensResponse>> getTokens() = 0;
       virtual std::shared_ptr<Promise<void>> clearCachedAccessToken(const std::string& accessTokenString) = 0;
       virtual std::shared_ptr<Promise<void>> signOut() = 0;

--- a/nitrogen/generated/shared/c++/OneTapSuccessData.hpp
+++ b/nitrogen/generated/shared/c++/OneTapSuccessData.hpp
@@ -33,6 +33,7 @@ namespace margelo::nitro::nitrogooglesignin { struct OneTapUser; }
 
 #include "OneTapUser.hpp"
 #include <string>
+#include <vector>
 #include <NitroModules/Null.hpp>
 #include <variant>
 #include <optional>
@@ -45,12 +46,13 @@ namespace margelo::nitro::nitrogooglesignin {
   struct OneTapSuccessData final {
   public:
     OneTapUser user     SWIFT_PRIVATE;
+    std::vector<std::string> scopes     SWIFT_PRIVATE;
     std::string idToken     SWIFT_PRIVATE;
     std::optional<std::variant<nitro::NullType, std::string>> serverAuthCode     SWIFT_PRIVATE;
 
   public:
     OneTapSuccessData() = default;
-    explicit OneTapSuccessData(OneTapUser user, std::string idToken, std::optional<std::variant<nitro::NullType, std::string>> serverAuthCode): user(user), idToken(idToken), serverAuthCode(serverAuthCode) {}
+    explicit OneTapSuccessData(OneTapUser user, std::vector<std::string> scopes, std::string idToken, std::optional<std::variant<nitro::NullType, std::string>> serverAuthCode): user(user), scopes(scopes), idToken(idToken), serverAuthCode(serverAuthCode) {}
 
   public:
     friend bool operator==(const OneTapSuccessData& lhs, const OneTapSuccessData& rhs) = default;
@@ -67,6 +69,7 @@ namespace margelo::nitro {
       jsi::Object obj = arg.asObject(runtime);
       return margelo::nitro::nitrogooglesignin::OneTapSuccessData(
         JSIConverter<margelo::nitro::nitrogooglesignin::OneTapUser>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "user"))),
+        JSIConverter<std::vector<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "scopes"))),
         JSIConverter<std::string>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "idToken"))),
         JSIConverter<std::optional<std::variant<nitro::NullType, std::string>>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "serverAuthCode")))
       );
@@ -74,6 +77,7 @@ namespace margelo::nitro {
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const margelo::nitro::nitrogooglesignin::OneTapSuccessData& arg) {
       jsi::Object obj(runtime);
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "user"), JSIConverter<margelo::nitro::nitrogooglesignin::OneTapUser>::toJSI(runtime, arg.user));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "scopes"), JSIConverter<std::vector<std::string>>::toJSI(runtime, arg.scopes));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "idToken"), JSIConverter<std::string>::toJSI(runtime, arg.idToken));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "serverAuthCode"), JSIConverter<std::optional<std::variant<nitro::NullType, std::string>>>::toJSI(runtime, arg.serverAuthCode));
       return obj;
@@ -87,6 +91,7 @@ namespace margelo::nitro {
         return false;
       }
       if (!JSIConverter<margelo::nitro::nitrogooglesignin::OneTapUser>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "user")))) return false;
+      if (!JSIConverter<std::vector<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "scopes")))) return false;
       if (!JSIConverter<std::string>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "idToken")))) return false;
       if (!JSIConverter<std::optional<std::variant<nitro::NullType, std::string>>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "serverAuthCode")))) return false;
       return true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-google-signin",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Google Sign-In and One Tap for React Native and Expo — OAuth 2.0 / OpenID Connect with Android Credential Manager and Google Sign-In SDK (iOS). Powered by Nitro Modules.",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index.js",

--- a/skills/react-native-nitro-google-signin/SKILL.md
+++ b/skills/react-native-nitro-google-signin/SKILL.md
@@ -38,6 +38,7 @@ Requires RN ≥ 0.76. **Not Expo Go** — use `expo-dev-client`.
 | iOS offline grant | Silent `signIn()` returns `serverAuthCode: null` — use `createAccount()` for initial code |
 | `revokeAccess` | Android: by email/id. iOS: current session only (throws if id mismatch) |
 | `getTokens` | After sign-in; throws `SIGN_IN_REQUIRED` if no session. iOS: call `clearCachedAccessToken` before retry after 401 |
+| `getCurrentUser` | Sync; returns user + `scopes` or `null`. Check scopes before `requestScopes` for existing users |
 | Flow order | `checkPlayServices` → `signIn` → `createAccount` → `presentExplicitSignIn` |
 | Android `autoDetect` | Needs `google-services.json` + `com.google.gms.google-services` plugin |
 | iOS | `GoogleService-Info.plist` + `REVERSED_CLIENT_ID` URL scheme |

--- a/skills/react-native-nitro-google-signin/examples.md
+++ b/skills/react-native-nitro-google-signin/examples.md
@@ -22,18 +22,26 @@ await GoogleOneTapSignIn.signOut()
 
 ## Extra scopes
 
-`requestScopes()` returns an **`accessToken`** for on-device Google API calls. Set `offlineAccess: true` in `configure()` only when you also need a non-null `serverAuthCode` for your backend:
+`requestScopes()` returns an **`accessToken`** for on-device Google API calls. Set `offlineAccess: true` in `configure()` only when you also need a non-null `serverAuthCode` for your backend.
+
+Check granted scopes first with **`getCurrentUser()`** so existing users are not prompted again:
+
+```ts
+const CALENDAR = 'https://www.googleapis.com/auth/calendar.readonly'
+const current = GoogleOneTapSignIn.getCurrentUser()
+if (!current?.scopes.includes(CALENDAR)) {
+  const { accessToken, serverAuthCode } = await GoogleOneTapSignIn.requestScopes([
+    CALENDAR,
+  ])
+  // use accessToken for Google APIs from the device
+}
+```
 
 ```ts
 GoogleOneTapSignIn.configure({
   webClientId: 'YOUR_WEB_CLIENT_ID.apps.googleusercontent.com',
   // offlineAccess: true, // optional — only for serverAuthCode
 })
-
-const { accessToken, serverAuthCode } = await GoogleOneTapSignIn.requestScopes([
-  'https://www.googleapis.com/auth/calendar.readonly',
-])
-// use accessToken for Google APIs from the device
 ```
 
 On **iOS**, use `createAccount()` or `presentExplicitSignIn()` (not silent `signIn()`) for the initial offline grant that returns a `serverAuthCode`.

--- a/skills/react-native-nitro-google-signin/reference.md
+++ b/skills/react-native-nitro-google-signin/reference.md
@@ -18,6 +18,7 @@ Full types: https://react-native-nitro-google-sign-in.github.io/docs/guide/api-r
 | `createAccount()`                | All accounts / interactive                                                                           |
 | `presentExplicitSignIn()`        | Explicit Sign in with Google UI (Android dialog)                                                     |
 | `requestScopes(scopes)`          | `{ accessToken, serverAuthCode }` after sign-in; **`offlineAccess: true` required only for non-null `serverAuthCode`** — use `accessToken` for on-device Google APIs |
+| `getCurrentUser()`                 | Sync: current user + `scopes`, or `null`. Use before `requestScopes` to skip duplicate consent |
 | `getTokens()`                      | `{ idToken, accessToken }` after sign-in; throws `SIGN_IN_REQUIRED` if not signed in |
 | `clearCachedAccessToken(token)`    | Clears cached access token (Android) or marks session for refresh (iOS) |
 | `signOut()`                      | iOS GIDSignOut; Android disables auto sign-in semantics                                              |

--- a/src/GoogleOneTapSignIn.ts
+++ b/src/GoogleOneTapSignIn.ts
@@ -5,6 +5,7 @@ import type {
   OneTapAuthorizationResult,
   OneTapConfigureParams,
   OneTapResponse,
+  OneTapSuccessData,
 } from './specs/nitro-google-signin.nitro'
 
 const hybrid =
@@ -91,6 +92,22 @@ export const GoogleOneTapSignIn = {
    */
   requestScopes(scopes: string[]): Promise<OneTapAuthorizationResult> {
     return hybrid.requestScopes(scopes)
+  },
+
+  /**
+   * Returns the currently signed-in user and granted scopes, or `null` if none.
+   *
+   * Synchronous. Use after sign-in (or on app launch) to inspect `scopes` before calling
+   * {@link requestScopes} — e.g. only prompt existing users who have not consented to a
+   * newly added Drive scope.
+   *
+   * **Android:** last Credential Manager session from encrypted storage.
+   * **iOS:** `GIDSignIn.sharedInstance.currentUser` / `grantedScopes`.
+   *
+   * `serverAuthCode` is always `null` (one-time codes are not persisted).
+   */
+  getCurrentUser(): OneTapSuccessData | null {
+    return hybrid.getCurrentUser()
   },
 
   /**

--- a/src/specs/nitro-google-signin.nitro.ts
+++ b/src/specs/nitro-google-signin.nitro.ts
@@ -22,9 +22,19 @@ export interface OneTapUser {
   photo: string | null
 }
 
-/** Payload when a sign-in method returns `type: 'success'`. */
+/** Payload when a sign-in method returns `type: 'success'`, or from {@link NitroGoogleSignin.getCurrentUser}. */
 export interface OneTapSuccessData {
   user: OneTapUser
+  /**
+   * OAuth scopes currently granted for this user.
+   *
+   * Use this to decide whether {@link NitroGoogleSignin.requestScopes} is needed
+   * (e.g. after adding a new Drive scope for existing users).
+   *
+   * **Android:** persisted from `configure({ scopes })` plus scopes granted via
+   * `requestScopes()`. **iOS:** from `GIDGoogleUser.grantedScopes`.
+   */
+  scopes: string[]
   /** OpenID Connect ID token (JWT). Verify on your backend with Google's keys. */
   idToken: string
   /**
@@ -33,6 +43,9 @@ export interface OneTapSuccessData {
    * **Requires `configure({ offlineAccess: true })`.** When `offlineAccess` is `false`
    * (the default), this is always `null` — including after `requestScopes()`.
    * Exchange the code on your backend for refresh tokens.
+   *
+   * On {@link NitroGoogleSignin.getCurrentUser}, this is always `null` (auth codes are
+   * one-time and not persisted).
    */
   serverAuthCode: string | null
 }
@@ -128,6 +141,18 @@ export interface NitroGoogleSignin
   createAccount(): Promise<OneTapResponse>
   presentExplicitSignIn(): Promise<OneTapResponse>
   requestScopes(scopes: string[]): Promise<OneTapAuthorizationResult>
+  /**
+   * Returns the currently signed-in user and granted scopes, or `null` if none.
+   *
+   * Synchronous (no Promise). Use to check whether incremental consent via
+   * {@link requestScopes} is still needed for existing users.
+   *
+   * **Android:** reads the last Credential Manager session from encrypted storage.
+   * **iOS:** reads `GIDSignIn.sharedInstance.currentUser` (including `grantedScopes`).
+   *
+   * `serverAuthCode` is always `null` here — auth codes are one-time and not persisted.
+   */
+  getCurrentUser(): OneTapSuccessData | null
   /**
    * Returns the current user's ID and access tokens after sign-in.
    *


### PR DESCRIPTION
## Summary

- Add synchronous `GoogleOneTapSignIn.getCurrentUser()` returning the signed-in user + granted `scopes`, or `null` (API parity with `@react-native-google-signin/google-signin`)
- Add `scopes: string[]` to `OneTapSuccessData` (sign-in success + `getCurrentUser`)
- **Android:** persist profile/scopes/id token; return from encrypted session storage
- **iOS:** map `GIDGoogleUser.grantedScopes` on success and `getCurrentUser`
- Update docs (submodule), agent skill, README, and example apps

Implements #49

## Test plan

- [x] `bun run codegen` / `bun run build` / `bun run typecheck`
- [x] `cd docs && bun run build`
- [ ] Android: sign in → `getCurrentUser()` returns user + default scopes (`openid`/`email`/`profile` + configure scopes)
- [ ] Android: `requestScopes([drive])` → `getCurrentUser().scopes` includes Drive; second call can skip when already granted
- [ ] Android: `signOut()` → `getCurrentUser()` returns `null`
- [ ] iOS: same flow via `GIDSignIn.currentUser.grantedScopes`
- [ ] Example / Expo example: **Get current user** button shows email and scopes

## Docs

- [x] Updated API reference, usage, skill, README (docs submodule merged in [docs PR #4](https://github.com/react-native-nitro-google-sign-in/react-native-nitro-google-sign-in.github.io/pull/4))


Made with [Cursor](https://cursor.com)