### PR TITLE
fix(expo): allow AppCheckCore 11.3+ with Firebase App Check

### DIFF
--- a/NitroGoogleSignin.podspec
+++ b/NitroGoogleSignin.podspec
@@ -27,9 +27,10 @@ Pod::Spec.new do |s|
 
   s.dependency 'React-jsi'
   s.dependency 'React-callinvoker'
-  # GoogleSignIn 9.2.0 can resolve AppCheckCore 11.3.0, which adds RecaptchaInterop and
-  # breaks static CocoaPods integration on Expo 56. Cap GoogleSignIn; Expo apps also get
-  # AppCheckCore modular-header pods from the config plugin. See issue #24.
-  s.dependency 'GoogleSignIn', '~> 9.0', '< 9.2.0'
+  # GoogleSignIn 9.2+ may resolve AppCheckCore ≥ 11.3 (RecaptchaInterop). Expo's config
+  # plugin and bare Podfile snippets enable modular headers for AppCheckCore,
+  # GoogleUtilities, and RecaptchaInterop so static CocoaPods / Firebase App Check work.
+  # See issue #24.
+  s.dependency 'GoogleSignIn', '~> 9.0'
   install_modules_dependencies(s)
 end

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -15,8 +15,9 @@ if linkage != nil
 end
 
 target 'NitroGoogleSigninExample' do
-  # react-native-nitro-google-signin: AppCheckCore 11.3.0 + static CocoaPods needs modular headers.
-  pod 'AppCheckCore', '< 11.3.0', :modular_headers => true
+  # react-native-nitro-google-signin: AppCheckCore ≥ 11.3 + static CocoaPods needs modular headers.
+  # Do not pin AppCheckCore < 11.3 — conflicts with Firebase App Check (~> 11.3). See issue #24.
+  pod 'AppCheckCore', :modular_headers => true
   pod 'GoogleUtilities', :modular_headers => true
   pod 'RecaptchaInterop', :modular_headers => true
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-google-signin",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Google Sign-In and One Tap for React Native and Expo — OAuth 2.0 / OpenID Connect with Android Credential Manager and Google Sign-In SDK (iOS). Powered by Nitro Modules.",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index.js",

--- a/plugin/withNitroGoogleSignIn.js
+++ b/plugin/withNitroGoogleSignIn.js
@@ -78,8 +78,13 @@ const withGoogleServicesFilePaths = (config, options) => {
 
 const GOOGLE_SIGN_IN_PODFILE_TAG = 'react-native-nitro-google-signin-google-pods'
 
-/** Pods required for static CocoaPods / Expo 56 when GoogleSignIn pulls AppCheckCore. */
-const GOOGLE_SIGN_IN_PODFILE_PODS = `  pod 'AppCheckCore', '< 11.3.0', :modular_headers => true
+/**
+ * Pods required for static CocoaPods / Expo when AppCheckCore (≥ 11.3) pulls
+ * GoogleUtilities + RecaptchaInterop. Do not pin AppCheckCore below 11.3 —
+ * @react-native-firebase/app-check (and GoogleSignIn 9.2+) need ~> 11.3.
+ * See issue #24.
+ */
+const GOOGLE_SIGN_IN_PODFILE_PODS = `  pod 'AppCheckCore', :modular_headers => true
   pod 'GoogleUtilities', :modular_headers => true
   pod 'RecaptchaInterop', :modular_headers => true`
 

--- a/skills/react-native-nitro-google-signin/SKILL.md
+++ b/skills/react-native-nitro-google-signin/SKILL.md
@@ -83,7 +83,7 @@ if (isSuccessResponse(response)) {
 | `type: 'cancelled'` after picking account (Android release/Play) | Missing **Play App Signing** / release SHA-1 on Android OAuth client — [troubleshooting](https://react-native-nitro-google-sign-in.github.io/docs/guide/troubleshooting#cancelled-after-account-pick) |
 | `default_web_client_id was not found` | Add `google-services.json` + Gradle plugin |
 | iOS redirect fails | Fix `REVERSED_CLIENT_ID` URL scheme |
-| `pod install` / Expo prebuild — AppCheckCore modular headers | Expo: `prebuild --clean` (plugin patches Podfile). Bare: add AppCheckCore/GoogleUtilities/RecaptchaInterop pods to `ios/Podfile` — [troubleshooting](https://react-native-nitro-google-sign-in.github.io/docs/guide/troubleshooting#ios-pod-install-fails--appcheckcore--recaptchainterop-expo-56) |
+| `pod install` / Expo prebuild — AppCheckCore / RecaptchaInterop (or conflict with Firebase App Check) | Expo: upgrade package + `prebuild --clean` (plugin adds modular headers, **no** AppCheckCore `< 11.3` pin). Bare: add AppCheckCore/GoogleUtilities/RecaptchaInterop with `:modular_headers => true` — [troubleshooting](https://react-native-nitro-google-sign-in.github.io/docs/guide/troubleshooting#ios-pod-install-fails--appcheckcore--recaptchainterop-expo-56) |
 | Nitro not found | Rebuild dev client / `bundle exec pod install --project-directory="ios"` |
 | Sign-in OK in debug, fails in release | Consumer ProGuard rules ship with library; avoid `-keep androidx.**`; test `assembleRelease`. Also check release/Play SHA-1 (see cancelled-after-account-pick above) |
 


### PR DESCRIPTION
## Summary

- Remove the Expo/bare `AppCheckCore < 11.3.0` pin that conflicts with `@react-native-firebase/app-check` (`AppCheckCore ~> 11.3`).
- Keep Podfile modular headers for `AppCheckCore`, `GoogleUtilities`, and `RecaptchaInterop` (still required for Expo static CocoaPods).
- Allow `GoogleSignIn ~> 9.0` (including 9.2+) now that modular headers cover AppCheckCore 11.3+.

Fixes #24

## Why not drop the plugin patch?

Probed CocoaPods locally:

| Setup | Result |
| ----- | ------ |
| `GoogleSignIn 9.2.0` alone (latest) | **Fails** — AppCheckCore 11.3.1 + RecaptchaInterop still need modular headers |
| `GoogleSignIn` + `FirebaseAppCheck` + modular headers (**no** version pin) | **Succeeds** (AppCheckCore 11.3.1, GoogleSignIn 9.2.0) |
| Old pin `AppCheckCore < 11.3.0` + `FirebaseAppCheck` | **Fails** — exact reporter conflict |

Latest Google Sign-In iOS (9.2.0) does not fix static-library module maps; the plugin Podfile patch remains necessary, without the version pin.

## Test plan

- [ ] Expo app with this package + `@react-native-firebase/auth` + `@react-native-firebase/app-check`: `npx expo prebuild --clean` then `pod install` succeeds
- [ ] Expo app without Firebase App Check: prebuild / pod install still succeeds
- [ ] Bare example: Podfile modular-header snippet without `< 11.3.0` pin; `bundle exec pod install --project-directory=ios`
- [ ] Docs troubleshooting section reflects modular headers (no pin)

## Docs

- [x] Updated `docs/content/guide/troubleshooting.md` and agent skill


Made with [Cursor](https://cursor.com)