### PR TITLE
fix(android): render GoogleSignInButton in-process

### DIFF
--- a/android/src/main/java/com/margelo/nitro/nitrogooglesignin/HybridGoogleSignInButton.kt
+++ b/android/src/main/java/com/margelo/nitro/nitrogooglesignin/HybridGoogleSignInButton.kt
@@ -1,29 +1,57 @@
 package com.margelo.nitro.nitrogooglesignin
 
 import android.content.Context
+import android.graphics.PorterDuff
+import android.graphics.Typeface
+import android.util.TypedValue
 import android.view.Gravity
 import android.view.View
 import android.view.View.MeasureSpec
+import android.widget.Button
 import android.widget.FrameLayout
 import androidx.annotation.Keep
+import androidx.core.content.res.ResourcesCompat
+import androidx.core.graphics.drawable.DrawableCompat
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.uimanager.ThemedReactContext
-import com.google.android.gms.common.SignInButton
+import com.google.android.gms.base.R as GmsBaseR
 
 private const val BUTTON_HEIGHT_DP = 48
 
+/**
+ * In-process Google Sign-In button using Play services branding assets
+ * (same resources as GMS's local `SignInButton` placeholder).
+ *
+ * Avoids `com.google.android.gms.common.SignInButton`, which loads a Dynamite
+ * remote view that can measure/paint as empty on some Android / Play services
+ * combinations (see issue #53).
+ */
 @Keep
 @DoNotStrip
 internal class GoogleSignInButtonLayout(
   context: Context,
 ) : FrameLayout(context) {
-  val signInButton: SignInButton = SignInButton(context)
+  val signInButton: Button =
+    Button(context, null, android.R.attr.buttonStyle).apply {
+      isAllCaps = false
+      transformationMethod = null
+      typeface = Typeface.DEFAULT_BOLD
+      setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
+      stateListAnimator = null
+      elevation = 0f
+    }
 
   var buttonSize: GoogleSignInButtonNativeSize = GoogleSignInButtonNativeSize.STANDARD
     set(value) {
       field = value
-      applyButtonSize()
+      applyAppearance()
       requestLayout()
+    }
+
+  var colorScheme: GoogleSignInButtonColorScheme = GoogleSignInButtonColorScheme.LIGHT
+    set(value) {
+      field = value
+      applyAppearance()
     }
 
   var contentAlignment: GoogleSignInButtonContentAlignment =
@@ -34,8 +62,6 @@ internal class GoogleSignInButtonLayout(
     }
 
   init {
-    applyButtonSize()
-    signInButton.setColorScheme(SignInButton.COLOR_LIGHT)
     addView(
       signInButton,
       LayoutParams(
@@ -43,16 +69,77 @@ internal class GoogleSignInButtonLayout(
         LayoutParams.WRAP_CONTENT,
       ),
     )
+    applyAppearance()
   }
 
-  fun applyButtonSize() {
-    signInButton.setSize(
+  fun applyAppearance() {
+    val resources = context.resources
+    val theme = context.theme
+    val minPx = desiredHeightPx()
+    signInButton.minHeight = minPx
+    signInButton.minimumHeight = minPx
+    signInButton.minWidth = desiredWidthPx()
+    signInButton.minimumWidth = desiredWidthPx()
+
+    val backgroundRes =
       when (buttonSize) {
-        GoogleSignInButtonNativeSize.WIDE -> SignInButton.SIZE_WIDE
-        GoogleSignInButtonNativeSize.ICON -> SignInButton.SIZE_ICON_ONLY
-        GoogleSignInButtonNativeSize.STANDARD -> SignInButton.SIZE_STANDARD
-      },
+        GoogleSignInButtonNativeSize.ICON ->
+          if (colorScheme == GoogleSignInButtonColorScheme.DARK) {
+            GmsBaseR.drawable.common_google_signin_btn_icon_dark
+          } else {
+            GmsBaseR.drawable.common_google_signin_btn_icon_light
+          }
+        else ->
+          if (colorScheme == GoogleSignInButtonColorScheme.DARK) {
+            GmsBaseR.drawable.common_google_signin_btn_text_dark
+          } else {
+            GmsBaseR.drawable.common_google_signin_btn_text_light
+          }
+      }
+
+    val raw =
+      ResourcesCompat.getDrawable(resources, backgroundRes, theme)
+        ?: return
+    val drawable = DrawableCompat.wrap(raw.mutate())
+    ResourcesCompat.getColorStateList(
+      resources,
+      GmsBaseR.color.common_google_signin_btn_tint,
+      theme,
+    )?.let { tint ->
+      DrawableCompat.setTintList(drawable, tint)
+      DrawableCompat.setTintMode(drawable, PorterDuff.Mode.SRC_ATOP)
+    }
+    signInButton.background = drawable
+
+    val textColorRes =
+      if (colorScheme == GoogleSignInButtonColorScheme.DARK) {
+        GmsBaseR.color.common_google_signin_btn_text_dark
+      } else {
+        GmsBaseR.color.common_google_signin_btn_text_light
+      }
+    signInButton.setTextColor(
+      ResourcesCompat.getColorStateList(resources, textColorRes, theme),
     )
+
+    when (buttonSize) {
+      GoogleSignInButtonNativeSize.ICON -> {
+        signInButton.text = null
+        signInButton.contentDescription =
+          resources.getString(GmsBaseR.string.common_signin_button_text_long)
+      }
+      GoogleSignInButtonNativeSize.WIDE -> {
+        val label = resources.getString(GmsBaseR.string.common_signin_button_text_long)
+        signInButton.text = label
+        signInButton.contentDescription = label
+      }
+      GoogleSignInButtonNativeSize.STANDARD -> {
+        val label = resources.getString(GmsBaseR.string.common_signin_button_text)
+        signInButton.text = label
+        signInButton.contentDescription = label
+      }
+    }
+
+    signInButton.gravity = Gravity.CENTER
   }
 
   fun desiredWidthPx(): Int {
@@ -60,14 +147,14 @@ internal class GoogleSignInButtonLayout(
     val widthDp =
       when (buttonSize) {
         GoogleSignInButtonNativeSize.WIDE -> 312
-        GoogleSignInButtonNativeSize.ICON -> 48
+        GoogleSignInButtonNativeSize.ICON -> BUTTON_HEIGHT_DP
         GoogleSignInButtonNativeSize.STANDARD -> 230
       }
-    return (widthDp * density).toInt()
+    return (widthDp * density + 0.5f).toInt()
   }
 
   fun desiredHeightPx(): Int =
-    (BUTTON_HEIGHT_DP * resources.displayMetrics.density).toInt()
+    (BUTTON_HEIGHT_DP * resources.displayMetrics.density + 0.5f).toInt()
 
   private fun measureSignInButton(): Pair<Int, Int> {
     val widthSpec = MeasureSpec.makeMeasureSpec(desiredWidthPx(), MeasureSpec.EXACTLY)
@@ -135,19 +222,14 @@ class HybridGoogleSignInButton(
 
   override val view: View = buttonLayout
 
-  private val signInButton: SignInButton
+  private val signInButton: Button
     get() = buttonLayout.signInButton
 
   override var colorScheme: GoogleSignInButtonColorScheme =
     GoogleSignInButtonColorScheme.LIGHT
     set(value) {
       field = value
-      signInButton.setColorScheme(
-        when (value) {
-          GoogleSignInButtonColorScheme.DARK -> SignInButton.COLOR_DARK
-          GoogleSignInButtonColorScheme.LIGHT -> SignInButton.COLOR_LIGHT
-        },
-      )
+      buttonLayout.colorScheme = value
     }
 
   override var size: GoogleSignInButtonNativeSize = GoogleSignInButtonNativeSize.STANDARD
@@ -185,7 +267,7 @@ class HybridGoogleSignInButton(
   }
 
   override fun afterUpdate() {
-    buttonLayout.applyButtonSize()
+    buttonLayout.applyAppearance()
     buttonLayout.requestLayout()
   }
 }

--- a/android/src/main/java/com/nitrogooglesignin/GoogleSignInButtonShadowNode.kt
+++ b/android/src/main/java/com/nitrogooglesignin/GoogleSignInButtonShadowNode.kt
@@ -1,22 +1,19 @@
 package com.nitrogooglesignin
 
-import android.view.View
 import com.facebook.react.uimanager.LayoutShadowNode
 import com.facebook.react.uimanager.PixelUtil
-import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.yoga.YogaMeasureFunction
 import com.facebook.yoga.YogaMeasureMode
 import com.facebook.yoga.YogaMeasureOutput
 import com.facebook.yoga.YogaNode
-import com.google.android.gms.common.SignInButton
 
 /**
- * Supplies intrinsic dimensions for the GMS [SignInButton], which often measures 0×0 otherwise.
+ * Paper (old architecture) intrinsic size for [GoogleSignInButton].
+ *
+ * Under Fabric / New Architecture this shadow node is not used — the JS
+ * wrapper applies default width/height from `size` instead.
  */
 internal class GoogleSignInButtonShadowNode : LayoutShadowNode(), YogaMeasureFunction {
-  private var measuredWidthPx = 0
-  private var measuredHeightPx = 0
-
   init {
     setMeasureFunction(this)
   }
@@ -28,44 +25,28 @@ internal class GoogleSignInButtonShadowNode : LayoutShadowNode(), YogaMeasureFun
     height: Float,
     heightMode: YogaMeasureMode,
   ): Long {
-    if (measuredWidthPx == 0) {
-      measureIntrinsicSize(themedContext)
-    }
+    val intrinsicWidth = PixelUtil.toPixelFromDIP(STANDARD_WIDTH_DP).toInt()
+    val intrinsicHeight = PixelUtil.toPixelFromDIP(BUTTON_HEIGHT_DP).toInt()
 
     val measuredWidth =
       when (widthMode) {
         YogaMeasureMode.EXACTLY -> width.toInt()
-        YogaMeasureMode.AT_MOST -> minOf(width.toInt(), measuredWidthPx)
-        else -> measuredWidthPx
+        YogaMeasureMode.AT_MOST -> minOf(width.toInt(), intrinsicWidth)
+        else -> intrinsicWidth
       }
 
     val measuredHeight =
       when (heightMode) {
         YogaMeasureMode.EXACTLY -> height.toInt()
-        YogaMeasureMode.AT_MOST -> minOf(height.toInt(), measuredHeightPx)
-        else -> measuredHeightPx
+        YogaMeasureMode.AT_MOST -> minOf(height.toInt(), intrinsicHeight)
+        else -> intrinsicHeight
       }
 
     return YogaMeasureOutput.make(measuredWidth, measuredHeight)
   }
 
-  private fun measureIntrinsicSize(context: ThemedReactContext) {
-    val fallbackWidth = PixelUtil.toPixelFromDIP(WIDE_WIDTH_DP).toInt()
-    val fallbackHeight = PixelUtil.toPixelFromDIP(BUTTON_HEIGHT_DP).toInt()
-
-    val button = SignInButton(context)
-    button.setSize(SignInButton.SIZE_WIDE)
-    val unspecified = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
-    button.measure(unspecified, unspecified)
-
-    measuredWidthPx =
-      if (button.measuredWidth > 0) button.measuredWidth else fallbackWidth
-    measuredHeightPx =
-      if (button.measuredHeight > 0) button.measuredHeight else fallbackHeight
-  }
-
   companion object {
-    private const val WIDE_WIDTH_DP = 312f
+    private const val STANDARD_WIDTH_DP = 230f
     private const val BUTTON_HEIGHT_DP = 48f
   }
 }

--- a/android/src/main/java/com/nitrogooglesignin/GoogleSignInButtonViewManager.kt
+++ b/android/src/main/java/com/nitrogooglesignin/GoogleSignInButtonViewManager.kt
@@ -12,8 +12,10 @@ import com.margelo.nitro.nitrogooglesignin.views.HybridGoogleSignInButtonStateUp
 import com.margelo.nitro.views.RecyclableView
 
 /**
- * Nitro "GoogleSignInButton" view manager with Yoga intrinsic sizing for GMS [SignInButton].
+ * Nitro "GoogleSignInButton" view manager with Paper Yoga intrinsic sizing.
  * (The generated [com.margelo.nitro.nitrogooglesignin.views.HybridGoogleSignInButtonManager] is final.)
+ *
+ * Fabric does not use [GoogleSignInButtonShadowNode]; the JS wrapper supplies default dimensions.
  */
 class GoogleSignInButtonViewManager : SimpleViewManager<View>() {
   init {

--- a/skills/react-native-nitro-google-signin/SKILL.md
+++ b/skills/react-native-nitro-google-signin/SKILL.md
@@ -85,6 +85,7 @@ if (isSuccessResponse(response)) {
 | iOS redirect fails | Fix `REVERSED_CLIENT_ID` URL scheme |
 | `pod install` / Expo prebuild — AppCheckCore / RecaptchaInterop (or conflict with Firebase App Check) | Expo: upgrade package + `prebuild --clean` (plugin adds modular headers, **no** AppCheckCore `< 11.3` pin). Bare: add AppCheckCore/GoogleUtilities/RecaptchaInterop with `:modular_headers => true` — [troubleshooting](https://react-native-nitro-google-sign-in.github.io/docs/guide/troubleshooting#ios-pod-install-fails--appcheckcore--recaptchainterop-expo-56) |
 | Nitro not found | Rebuild dev client / `bundle exec pod install --project-directory="ios"` |
+| Android button laid out but blank | Upgrade package (in-process branding button) + rebuild native app |
 | Sign-in OK in debug, fails in release | Consumer ProGuard rules ship with library; avoid `-keep androidx.**`; test `assembleRelease`. Also check release/Play SHA-1 (see cancelled-after-account-pick above) |
 
 ## More detail

--- a/skills/react-native-nitro-google-signin/reference.md
+++ b/skills/react-native-nitro-google-signin/reference.md
@@ -45,7 +45,7 @@ Helpers: `isSuccessResponse`, `isNoSavedCredentialFoundResponse`, `isCancelledRe
 
 ### Button
 
-`GoogleSignInButton`, `useGoogleSignInFromButton`, `GOOGLE_SIGN_IN_BUTTON_HEIGHT` (48), `signInBehavior`: `credentialManager` | `buttonFlow` | `none`
+`GoogleSignInButton`, `useGoogleSignInFromButton`, `GOOGLE_SIGN_IN_BUTTON_HEIGHT` (48), `GOOGLE_SIGN_IN_BUTTON_WIDTH` (`standard` 230 / `wide` 312 / `icon` 48), `signInBehavior`: `credentialManager` | `buttonFlow` | `none`
 
 ## Google Cloud & config files (bare + Expo)
 

--- a/src/GoogleSignInButton.tsx
+++ b/src/GoogleSignInButton.tsx
@@ -10,7 +10,10 @@ import {
   type GoogleSignInButtonSignInBehavior,
 } from './hooks/useGoogleSignInFromButton'
 import type { OneTapSuccessData } from './specs/nitro-google-signin.nitro'
-import type { GoogleSignInButtonViewProps } from './specs/GoogleSignInButton.nitro'
+import type {
+  GoogleSignInButtonNativeSize,
+  GoogleSignInButtonViewProps,
+} from './specs/GoogleSignInButton.nitro'
 
 export type {
   GoogleSignInButtonColorScheme,
@@ -26,6 +29,23 @@ export { GoogleSignInButtonHost, type GoogleSignInButtonRef } from './GoogleSign
 
 /** Recommended height for the SDK button (48pt/dp per Google branding). */
 export const GOOGLE_SIGN_IN_BUTTON_HEIGHT = 48
+
+/** Intrinsic widths (dp) matching Google branding / former GMS `SignInButton` sizes. */
+export const GOOGLE_SIGN_IN_BUTTON_WIDTH = {
+  standard: 230,
+  wide: 312,
+  icon: GOOGLE_SIGN_IN_BUTTON_HEIGHT,
+} as const
+
+/** Default layout size for Fabric (Paper uses a Yoga measure function on Android). */
+export function getGoogleSignInButtonIntrinsicStyle(
+  size: GoogleSignInButtonNativeSize = 'standard',
+): { width: number; height: number } {
+  return {
+    width: GOOGLE_SIGN_IN_BUTTON_WIDTH[size],
+    height: GOOGLE_SIGN_IN_BUTTON_HEIGHT,
+  }
+}
 
 export type GoogleSignInButtonProps = Pick<
   GoogleSignInButtonViewProps,
@@ -54,7 +74,11 @@ export type GoogleSignInButtonProps = Pick<
 >
 
 /**
- * Official SDK sign-in button (`GIDSignInButton` / `SignInButton`) as a Nitro HybridView.
+ * Official branded sign-in button as a Nitro HybridView.
+ *
+ * - **iOS:** `GIDSignInButton`
+ * - **Android:** in-process button using Play services branding assets (not the
+ *   Dynamite-backed `SignInButton`, which can paint blank on some devices)
  *
  * Default tap uses Credential Manager bottom sheet (`signIn` → `createAccount`), not
  * `presentExplicitSignIn` (Android account dialog). Use `signInBehavior="buttonFlow"` for that.
@@ -67,6 +91,8 @@ export function GoogleSignInButton({
   loading: loadingProp,
   disabled: disabledProp,
   contentAlignment = 'center',
+  size = 'standard',
+  style,
   hybridRef,
   ...rest
 }: GoogleSignInButtonProps): React.JSX.Element {
@@ -109,9 +135,16 @@ export function GoogleSignInButton({
     [hybridRef],
   )
 
+  const intrinsicStyle = useMemo(
+    () => getGoogleSignInButtonIntrinsicStyle(size),
+    [size],
+  )
+
   return (
     <GoogleSignInButtonHost
       {...rest}
+      size={size}
+      style={[intrinsicStyle, style]}
       contentAlignment={contentAlignment}
       disabled={disabled || loading}
       onPress={nativeOnPress}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 export { GoogleOneTapSignIn } from './GoogleOneTapSignIn'
 export {
   GOOGLE_SIGN_IN_BUTTON_HEIGHT,
+  GOOGLE_SIGN_IN_BUTTON_WIDTH,
+  getGoogleSignInButtonIntrinsicStyle,
   GoogleSignInButton,
   GoogleSignInButtonHost,
   type GoogleSignInButtonColorScheme,


### PR DESCRIPTION
## Summary

- Replace Android `com.google.android.gms.common.SignInButton` with an in-process `Button` using the same Play services branding drawables/strings as GMS’s local placeholder (avoids Dynamite remote views that can measure correctly but paint zero pixels).
- Apply default intrinsic width/height from `size` in JS so Fabric/New Architecture does not collapse to 0×0 without an explicit `style` (Paper shadow node remains for old architecture).
- Export `GOOGLE_SIGN_IN_BUTTON_WIDTH` and `getGoogleSignInButtonIntrinsicStyle`; update docs + agent skill.

Fixes #53

## Test plan

- [ ] Expo / bare Android, `newArchEnabled=true`, render `<GoogleSignInButton size="wide" signInBehavior="none" />` — button paints (logo + label), not empty space
- [ ] Same with `colorScheme="dark"` and `size="standard"` / `"icon"`
- [ ] Override `style={{ width: '100%', height: 48 }}` still layouts and paints
- [ ] Tap still fires `onPress` / built-in sign-in
- [ ] iOS unchanged (still `GIDSignInButton`)
- [ ] Rebuild native app after upgrading (Metro-only reload is insufficient)

## Docs

- [x] Updated docs submodule (`google-sign-in-button`, api-reference, troubleshooting) — [docs PR](https://github.com/react-native-nitro-google-sign-in/react-native-nitro-google-sign-in.github.io/pull/6)
- [x] Updated agent skill troubleshooting / reference


Made with [Cursor](https://cursor.com)